### PR TITLE
104572 get project

### DIFF
--- a/Dfe.Academies.Academisation.Data/Dfe.Academies.Academisation.Data.csproj
+++ b/Dfe.Academies.Academisation.Data/Dfe.Academies.Academisation.Data.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
       <PrivateAssets>all</PrivateAssets>

--- a/Dfe.Academies.Academisation.Data/ProjectAggregate/ProjectGetDataQuery.cs
+++ b/Dfe.Academies.Academisation.Data/ProjectAggregate/ProjectGetDataQuery.cs
@@ -1,0 +1,21 @@
+﻿using AutoFixture;
+using Dfe.Academies.Academisation.Domain.Core.ProjectAggregate;
+using Dfe.Academies.Academisation.Domain.ProjectAggregate;
+using Dfe.Academies.Academisation.IData.ProjectAggregate;
+using Dfe.Academies.Academisation.IDomain.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.Data.ProjectAggregate;
+
+public class ProjectGetDataQuery : IProjectGetDataQuery
+{
+	private readonly Fixture _fixture = new();
+
+	public async Task<IProject?> Execute(int id)
+	{
+		ProjectDetails projectDetails = _fixture.Create<ProjectDetails>();
+
+		await Task.CompletedTask;
+
+		return new Project(id, projectDetails);
+	}
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ProjectAggregate/ProjectDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ProjectAggregate/ProjectDetails.cs
@@ -1,0 +1,93 @@
+﻿namespace Dfe.Academies.Academisation.Domain.Core.ProjectAggregate;
+
+public record ProjectDetails(
+	int Urn,
+	int Laestab,
+	string? SchoolName = null,
+	string? LocalAuthority = null,
+	string? ApplicationReferenceNumber = null,
+	string? UkPrn = null,
+	string? ProjectStatus = null,
+	DateTime? ApplicationReceivedDate = null,
+	DateTime? AssignedDate = null,
+	DateTime? HeadTeacherBoardDate = null,
+	DateTime? OpeningDate = null,
+	DateTime? BaselineDate = null,
+
+	// la summary page
+	DateTime? LocalAuthorityInformationTemplateSentDate = null,
+	DateTime? LocalAuthorityInformationTemplateReturnedDate = null,
+	string? LocalAuthorityInformationTemplateComments = null,
+	string? LocalAuthorityInformationTemplateLink = null,
+	bool? LocalAuthorityInformationTemplateSectionComplete = null,
+
+	// school/trust info
+	string? RecommendationForProject = null,
+	string? Author = null,
+	string? Version = null,
+	string? ClearedBy = null,
+	string? AcademyOrderRequired = null,
+	string? PreviousHeadTeacherBoardDateQuestion = null,
+	DateTime? PreviousHeadTeacherBoardDate = null,
+	string? PreviousHeadTeacherBoardLink = null,
+	string? TrustReferenceNumber = null,
+	string? NameOfTrust = null,
+	string? SponsorReferenceNumber = null,
+	string? SponsorName = null,
+	string? AcademyTypeAndRoute = null,
+	DateTime? ProposedAcademyOpeningDate = null,
+	bool? SchoolAndTrustInformationSectionComplete = null,
+	decimal? ConversionSupportGrantAmount = null,  // had to make this nullable or move it to the top
+	string? ConversionSupportGrantChangeReason = null,
+
+	// general info
+	string? PublishedAdmissionNumber = null,
+	string? PartOfPfiScheme = null,
+	string? ViabilityIssues = null,
+	string? FinancialDeficit = null,
+	decimal? DistanceFromSchoolToTrustHeadquarters = null,
+	string? DistanceFromSchoolToTrustHeadquartersAdditionalInformation = null,
+	string? MemberOfParliamentParty = null,
+	string? MemberOfParliamentName = null,
+
+	bool? GeneralInformationSectionComplete = null,
+
+	// school performance ofsted information
+	string? SchoolPerformanceAdditionalInformation = null,
+
+	// rationale
+	string? RationaleForProject = null,
+	string? RationaleForTrust = null,
+	bool? RationaleSectionComplete = null,
+
+	// risk and issues
+	string? RisksAndIssues = null,
+	string? EqualitiesImpactAssessmentConsidered = null,
+	bool? RisksAndIssuesSectionComplete = null,
+
+	// school budget info
+	decimal? RevenueCarryForwardAtEndMarchCurrentYear = null,
+	decimal? ProjectedRevenueBalanceAtEndMarchNextYear = null,
+	decimal? CapitalCarryForwardAtEndMarchCurrentYear = null,
+	decimal? CapitalCarryForwardAtEndMarchNextYear = null,
+	string? SchoolBudgetInformationAdditionalInformation = null,
+	bool? SchoolBudgetInformationSectionComplete = null,
+
+	// pupil schools forecast
+	int? CurrentYearCapacity = null,
+	int? CurrentYearPupilNumbers = null,
+	int? YearOneProjectedCapacity = null,
+	int? YearOneProjectedPupilNumbers = null,
+	int? YearTwoProjectedCapacity = null,
+	int? YearTwoProjectedPupilNumbers = null,
+	int? YearThreeProjectedCapacity = null,
+	int? YearThreeProjectedPupilNumbers = null,
+	string? SchoolPupilForecastsAdditionalInformation = null,
+
+	// key stage performance tables
+	string? KeyStage2PerformanceAdditionalInformation = null,
+	string? KeyStage4PerformanceAdditionalInformation = null,
+	string? KeyStage5PerformanceAdditionalInformation = null,
+	string? Upin = null,
+	string? NewAcademyUrn = null
+);

--- a/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
+++ b/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
@@ -1,12 +1,13 @@
 ﻿using Dfe.Academies.Academisation.Domain.Core.ProjectAggregate;
+using Dfe.Academies.Academisation.IDomain.ProjectAggregate;
 
 namespace Dfe.Academies.Academisation.Domain.ProjectAggregate;
 
-public class Project
+public class Project : IProject
 {
 	private Project(ProjectDetails projectDetails)
 	{
-		ProjectDetails = projectDetails;
+		Details = projectDetails;
 	}
 
 	/// <summary>
@@ -15,10 +16,10 @@ public class Project
 	public Project(int id, ProjectDetails projectDetails)
 	{
 		Id = id;
-		ProjectDetails = projectDetails;
+		Details = projectDetails;
 	}
 
 	public int Id { get; }
 
-	public ProjectDetails ProjectDetails { get; }
+	public ProjectDetails Details { get; }
 }

--- a/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
+++ b/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
@@ -1,0 +1,24 @@
+﻿using Dfe.Academies.Academisation.Domain.Core.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.Domain.ProjectAggregate;
+
+public class Project
+{
+	private Project(ProjectDetails projectDetails)
+	{
+		ProjectDetails = projectDetails;
+	}
+
+	/// <summary>
+	/// This is the persistence constructor, only use from the data layer
+	/// </summary>
+	public Project(int id, ProjectDetails projectDetails)
+	{
+		Id = id;
+		ProjectDetails = projectDetails;
+	}
+
+	public int Id { get; }
+
+	public ProjectDetails ProjectDetails { get; }
+}

--- a/Dfe.Academies.Academisation.IData/ProjectAggregate/IProjectGetDataQuery.cs
+++ b/Dfe.Academies.Academisation.IData/ProjectAggregate/IProjectGetDataQuery.cs
@@ -1,0 +1,9 @@
+﻿using Dfe.Academies.Academisation.IDomain.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.IData.ProjectAggregate
+{
+	public interface IProjectGetDataQuery
+	{
+		Task<IProject?> Execute(int id);
+	}
+}

--- a/Dfe.Academies.Academisation.IDomain/Dfe.Academies.Academisation.IDomain.csproj
+++ b/Dfe.Academies.Academisation.IDomain/Dfe.Academies.Academisation.IDomain.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
+++ b/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
@@ -1,0 +1,10 @@
+﻿using Dfe.Academies.Academisation.Domain.Core.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.IDomain.ProjectAggregate;
+
+public interface IProject
+{
+	public int Id { get; }
+
+	public ProjectDetails ProjectDetails { get; }
+}

--- a/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
+++ b/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
@@ -6,5 +6,5 @@ public interface IProject
 {
 	public int Id { get; }
 
-	public ProjectDetails ProjectDetails { get; }
+	public ProjectDetails Details { get; }
 }

--- a/Dfe.Academies.Academisation.IService/Dfe.Academies.Academisation.IService.csproj
+++ b/Dfe.Academies.Academisation.IService/Dfe.Academies.Academisation.IService.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Dfe.Academies.Academisation.Core\Dfe.Academies.Academisation.Core.csproj" />
     <ProjectReference Include="..\Dfe.Academies.Academisation.Domain.Core\Dfe.Academies.Academisation.Domain.Core.csproj" />
+    <ProjectReference Include="..\Dfe.Academies.Academisation.IData\Dfe.Academies.Academisation.IData.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Dfe.Academies.Academisation.IService/Query/ILegacyProjectGetQuery.cs
+++ b/Dfe.Academies.Academisation.IService/Query/ILegacyProjectGetQuery.cs
@@ -4,5 +4,5 @@ namespace Dfe.Academies.Academisation.IService.Query;
 
 public interface ILegacyProjectGetQuery
 {
-	Task<LegacyProjectServiceModel> Execute(int id);
+	Task<LegacyProjectServiceModel?> Execute(int id);
 }

--- a/Dfe.Academies.Academisation.IService/Query/ILegacyProjectGetQuery.cs
+++ b/Dfe.Academies.Academisation.IService/Query/ILegacyProjectGetQuery.cs
@@ -1,0 +1,8 @@
+﻿using Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.IService.Query;
+
+public interface ILegacyProjectGetQuery
+{
+	Task<LegacyProjectServiceModel> Execute(int id);
+}

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/LegacyProjectServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/LegacyProjectServiceModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
 
-public record AcademyConversionProjectResponse(
+public record LegacyProjectServiceModel(
 	int Id,
 	int Urn,
 	int Laestab,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/LegacyProjectServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/LegacyProjectServiceModel.cs
@@ -1,0 +1,94 @@
+﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
+
+public record AcademyConversionProjectResponse(
+	int Id,
+	int Urn,
+	int Laestab,
+	string? SchoolName = null,
+	string? LocalAuthority = null,
+	string? ApplicationReferenceNumber = null,
+	string? UkPrn = null,
+	string? ProjectStatus = null,
+	DateTime? ApplicationReceivedDate = null,
+	DateTime? AssignedDate = null,
+	DateTime? HeadTeacherBoardDate = null,
+	DateTime? OpeningDate = null,
+	DateTime? BaselineDate = null,
+
+	// la summary page
+	DateTime? LocalAuthorityInformationTemplateSentDate = null,
+	DateTime? LocalAuthorityInformationTemplateReturnedDate = null,
+	string? LocalAuthorityInformationTemplateComments = null,
+	string? LocalAuthorityInformationTemplateLink = null,
+	bool? LocalAuthorityInformationTemplateSectionComplete = null,
+
+	// school/trust info
+	string? RecommendationForProject = null,
+	string? Author = null,
+	string? Version = null,
+	string? ClearedBy = null,
+	string? AcademyOrderRequired = null,
+	string? PreviousHeadTeacherBoardDateQuestion = null,
+	DateTime? PreviousHeadTeacherBoardDate = null,
+	string? PreviousHeadTeacherBoardLink = null,
+	string? TrustReferenceNumber = null,
+	string? NameOfTrust = null,
+	string? SponsorReferenceNumber = null,
+	string? SponsorName = null,
+	string? AcademyTypeAndRoute = null,
+	DateTime? ProposedAcademyOpeningDate = null,
+	bool? SchoolAndTrustInformationSectionComplete = null,
+	decimal? ConversionSupportGrantAmount = null,  // had to make this nullable or move it to the top
+	string? ConversionSupportGrantChangeReason = null,
+
+	// general info
+	string? PublishedAdmissionNumber = null,
+	string? PartOfPfiScheme = null,
+	string? ViabilityIssues = null,
+	string? FinancialDeficit = null,
+	decimal? DistanceFromSchoolToTrustHeadquarters = null,
+	string? DistanceFromSchoolToTrustHeadquartersAdditionalInformation = null,
+	string? MemberOfParliamentParty = null,
+	string? MemberOfParliamentName = null,
+
+	bool? GeneralInformationSectionComplete = null,
+
+	// school performance ofsted information
+	string? SchoolPerformanceAdditionalInformation = null,
+
+	// rationale
+	string? RationaleForProject = null,
+	string? RationaleForTrust = null,
+	bool? RationaleSectionComplete = null,
+
+	// risk and issues
+	string? RisksAndIssues = null,
+	string? EqualitiesImpactAssessmentConsidered = null,
+	bool? RisksAndIssuesSectionComplete = null,
+
+	// school budget info
+	decimal? RevenueCarryForwardAtEndMarchCurrentYear = null,
+	decimal? ProjectedRevenueBalanceAtEndMarchNextYear = null,
+	decimal? CapitalCarryForwardAtEndMarchCurrentYear = null,
+	decimal? CapitalCarryForwardAtEndMarchNextYear = null,
+	string? SchoolBudgetInformationAdditionalInformation = null,
+	bool? SchoolBudgetInformationSectionComplete = null,
+
+	// pupil schools forecast
+	int? CurrentYearCapacity = null,
+	int? CurrentYearPupilNumbers = null,
+	int? YearOneProjectedCapacity = null,
+	int? YearOneProjectedPupilNumbers = null,
+	int? YearTwoProjectedCapacity = null,
+	int? YearTwoProjectedPupilNumbers = null,
+	int? YearThreeProjectedCapacity = null,
+	int? YearThreeProjectedPupilNumbers = null,
+	string? SchoolPupilForecastsAdditionalInformation = null,
+
+	// key stage performance tables
+	string? KeyStage2PerformanceAdditionalInformation = null,
+	string? KeyStage4PerformanceAdditionalInformation = null,
+	string? KeyStage5PerformanceAdditionalInformation = null,
+	string? Upin = null,
+	string? NewAcademyUrn = null
+);

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ProjectAggregate/LegacyProjectServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ProjectAggregate/LegacyProjectServiceModelMapper.cs
@@ -1,0 +1,107 @@
+﻿using Dfe.Academies.Academisation.IDomain.ProjectAggregate;
+using Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.Service.Mappers.Legacy.ProjectAggregate;
+
+internal static class LegacyProjectServiceModelMapper
+{
+	internal static LegacyProjectServiceModel MapToServiceModel(this IProject project)
+	{
+		LegacyProjectServiceModel serviceModel = new(
+			project.Id,
+			project.Details.Urn,
+			project.Details.Laestab
+			)
+		{
+			SchoolName = project.Details.SchoolName,
+			LocalAuthority = project.Details.LocalAuthority,
+			ApplicationReferenceNumber = project.Details.ApplicationReferenceNumber,
+			UkPrn = project.Details.UkPrn,
+			ProjectStatus = project.Details.ProjectStatus,
+			ApplicationReceivedDate = project.Details.ApplicationReceivedDate,
+			AssignedDate = project.Details.AssignedDate,
+			HeadTeacherBoardDate = project.Details.HeadTeacherBoardDate,
+			OpeningDate = project.Details.OpeningDate,
+			BaselineDate = project.Details.BaselineDate,
+
+			// la summary page
+			LocalAuthorityInformationTemplateSentDate = project.Details.LocalAuthorityInformationTemplateSentDate,
+			LocalAuthorityInformationTemplateReturnedDate = project.Details.LocalAuthorityInformationTemplateReturnedDate,
+			LocalAuthorityInformationTemplateComments = project.Details.LocalAuthorityInformationTemplateComments,
+			LocalAuthorityInformationTemplateLink = project.Details.LocalAuthorityInformationTemplateLink,
+			LocalAuthorityInformationTemplateSectionComplete = project.Details.LocalAuthorityInformationTemplateSectionComplete,
+
+			// school/trust info
+			RecommendationForProject = project.Details.RecommendationForProject,
+			Author = project.Details.Author,
+			Version = project.Details.Version,
+			ClearedBy = project.Details.ClearedBy,
+			AcademyOrderRequired = project.Details.AcademyOrderRequired,
+			PreviousHeadTeacherBoardDateQuestion = project.Details.PreviousHeadTeacherBoardDateQuestion,
+			PreviousHeadTeacherBoardDate = project.Details.PreviousHeadTeacherBoardDate,
+			PreviousHeadTeacherBoardLink = project.Details.PreviousHeadTeacherBoardLink,
+			TrustReferenceNumber = project.Details.TrustReferenceNumber,
+			NameOfTrust = project.Details.NameOfTrust,
+			SponsorReferenceNumber = project.Details.SponsorReferenceNumber,
+			SponsorName = project.Details.SponsorName,
+			AcademyTypeAndRoute = project.Details.AcademyTypeAndRoute,
+			ProposedAcademyOpeningDate = project.Details.ProposedAcademyOpeningDate,
+			SchoolAndTrustInformationSectionComplete = project.Details.SchoolAndTrustInformationSectionComplete,
+			ConversionSupportGrantAmount = project.Details.ConversionSupportGrantAmount,  // had to make this nullable or move it to the top
+			ConversionSupportGrantChangeReason = project.Details.ConversionSupportGrantChangeReason,
+
+			// general info
+			PublishedAdmissionNumber = project.Details.PublishedAdmissionNumber,
+			PartOfPfiScheme = project.Details.PartOfPfiScheme,
+			ViabilityIssues = project.Details.ViabilityIssues,
+			FinancialDeficit = project.Details.FinancialDeficit,
+			DistanceFromSchoolToTrustHeadquarters = project.Details.DistanceFromSchoolToTrustHeadquarters,
+			DistanceFromSchoolToTrustHeadquartersAdditionalInformation = project.Details.DistanceFromSchoolToTrustHeadquartersAdditionalInformation,
+			MemberOfParliamentParty = project.Details.MemberOfParliamentParty,
+			MemberOfParliamentName = project.Details.MemberOfParliamentName,
+
+			GeneralInformationSectionComplete = project.Details.GeneralInformationSectionComplete,
+
+			// school performance ofsted information
+			SchoolPerformanceAdditionalInformation = project.Details.SchoolPerformanceAdditionalInformation,
+
+			// rationale
+			RationaleForProject = project.Details.RationaleForProject,
+			RationaleForTrust = project.Details.RationaleForTrust,
+			RationaleSectionComplete = project.Details.RationaleSectionComplete,
+
+			// risk and issues
+			RisksAndIssues = project.Details.RisksAndIssues,
+			EqualitiesImpactAssessmentConsidered = project.Details.EqualitiesImpactAssessmentConsidered,
+			RisksAndIssuesSectionComplete = project.Details.RisksAndIssuesSectionComplete,
+
+			// school budget info
+			RevenueCarryForwardAtEndMarchCurrentYear = project.Details.RevenueCarryForwardAtEndMarchCurrentYear,
+			ProjectedRevenueBalanceAtEndMarchNextYear = project.Details.ProjectedRevenueBalanceAtEndMarchNextYear,
+			CapitalCarryForwardAtEndMarchCurrentYear = project.Details.CapitalCarryForwardAtEndMarchCurrentYear,
+			CapitalCarryForwardAtEndMarchNextYear = project.Details.CapitalCarryForwardAtEndMarchNextYear,
+			SchoolBudgetInformationAdditionalInformation = project.Details.SchoolBudgetInformationAdditionalInformation,
+			SchoolBudgetInformationSectionComplete = project.Details.SchoolBudgetInformationSectionComplete,
+
+			// pupil schools forecast
+			CurrentYearCapacity = project.Details.CurrentYearCapacity,
+			CurrentYearPupilNumbers = project.Details.CurrentYearPupilNumbers,
+			YearOneProjectedCapacity = project.Details.YearOneProjectedCapacity,
+			YearOneProjectedPupilNumbers = project.Details.YearOneProjectedPupilNumbers,
+			YearTwoProjectedCapacity = project.Details.YearTwoProjectedCapacity,
+			YearTwoProjectedPupilNumbers = project.Details.YearTwoProjectedPupilNumbers,
+			YearThreeProjectedCapacity = project.Details.YearThreeProjectedCapacity,
+			YearThreeProjectedPupilNumbers = project.Details.YearThreeProjectedPupilNumbers,
+			SchoolPupilForecastsAdditionalInformation = project.Details.SchoolPupilForecastsAdditionalInformation,
+
+			// key stage performance tables
+			KeyStage2PerformanceAdditionalInformation = project.Details.KeyStage2PerformanceAdditionalInformation,
+			KeyStage4PerformanceAdditionalInformation = project.Details.KeyStage4PerformanceAdditionalInformation,
+			KeyStage5PerformanceAdditionalInformation = project.Details.KeyStage5PerformanceAdditionalInformation,
+			Upin = project.Details.Upin,
+			NewAcademyUrn = project.Details.NewAcademyUrn
+		};
+
+		return serviceModel;
+	}
+}

--- a/Dfe.Academies.Academisation.Service/Queries/LegacyProjectGetQuery.cs
+++ b/Dfe.Academies.Academisation.Service/Queries/LegacyProjectGetQuery.cs
@@ -1,0 +1,24 @@
+﻿using Dfe.Academies.Academisation.IData.ProjectAggregate;
+using Dfe.Academies.Academisation.IDomain.ProjectAggregate;
+using Dfe.Academies.Academisation.IService.Query;
+using Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
+using Dfe.Academies.Academisation.Service.Mappers.Legacy.ProjectAggregate;
+
+namespace Dfe.Academies.Academisation.Service.Queries;
+
+public class LegacyProjectGetQuery : ILegacyProjectGetQuery
+{
+	private readonly IProjectGetDataQuery _dataQuery;
+
+	public LegacyProjectGetQuery(IProjectGetDataQuery dataQuery)
+	{
+		_dataQuery = dataQuery;
+	}
+
+	public async Task<LegacyProjectServiceModel?> Execute(int id)
+	{
+		IProject? project = await _dataQuery.Execute(id);
+
+		return project?.MapToServiceModel();
+	}
+}

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ApplicationAggregate/ApplicationCreateTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ApplicationAggregate/ApplicationCreateTests.cs
@@ -73,7 +73,7 @@ public class ApplicationCreateTests
 		var result = await applicationController.Post(applicationCreateRequestModel);
 
 		// assert
-		CreatedAtRouteResult createdAtRouteResult = DfeAssert.CreatedAtRoute(result, "Get");
+		CreatedAtRouteResult createdAtRouteResult = DfeAssert.CreatedAtRoute(result, "GetApplication");
 
 		object? idValue = createdAtRouteResult.RouteValues!["id"];
 		int id = Assert.IsType<int>(idValue);

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/ProjectGetTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/ProjectGetTests.cs
@@ -1,0 +1,39 @@
+﻿using AutoFixture;
+using Dfe.Academies.Academisation.Core.Test;
+using Dfe.Academies.Academisation.Data.ProjectAggregate;
+using Dfe.Academies.Academisation.IData.ProjectAggregate;
+using Dfe.Academies.Academisation.IService.Query;
+using Dfe.Academies.Academisation.Service.Queries;
+using Dfe.Academies.Academisation.WebApi.Controllers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate;
+
+public class ProjectGetTests
+{
+	private readonly Fixture _fixture = new();
+
+	private readonly IProjectGetDataQuery _projectGetDataQuery;
+	private readonly ILegacyProjectGetQuery _legacyProjectGetQuery;
+	private readonly LegacyProjectController _legacyProjectController;
+
+	public ProjectGetTests()
+	{
+		_projectGetDataQuery = new ProjectGetDataQuery();
+		_legacyProjectGetQuery = new LegacyProjectGetQuery(_projectGetDataQuery);
+
+		_legacyProjectController = new LegacyProjectController(_legacyProjectGetQuery);
+	}
+
+	[Fact]
+	public async Task NoPreconditions___ProjectReturned()
+	{
+		int id = _fixture.Create<int>();
+
+		// act
+		var result = await _legacyProjectController.Get(id);
+
+		// assert
+		Assert.IsType<OkObjectResult>(result.Result);
+	}
+}

--- a/Dfe.Academies.Academisation.WebApi.UnitTest/Controller/ConversionAdvisoryBoardDecisionControllerPostTests.cs
+++ b/Dfe.Academies.Academisation.WebApi.UnitTest/Controller/ConversionAdvisoryBoardDecisionControllerPostTests.cs
@@ -50,8 +50,8 @@ public class ConversionAdvisoryBoardDecisionControllerPostTests
 		var createdResult = Assert.IsType<CreatedAtRouteResult>(result.Result);
 
 		Assert.Equal(decisionServiceModel, createdResult.Value);
-		Assert.Equal(HttpMethods.Get, createdResult.RouteName);
-		Assert.Equal(decisionServiceModel.AdvisoryBoardDecisionId, createdResult.RouteValues!["id"]);
+		Assert.Equal("GetProject", createdResult.RouteName);
+		Assert.Equal(decisionServiceModel.AdvisoryBoardDecisionId, createdResult.RouteValues!["projectId"]);
 	}
 
 	[Fact]

--- a/Dfe.Academies.Academisation.WebApi.UnitTest/Controller/ConversionApplicationControllerTests.cs
+++ b/Dfe.Academies.Academisation.WebApi.UnitTest/Controller/ConversionApplicationControllerTests.cs
@@ -45,7 +45,7 @@ namespace Dfe.Academies.Academisation.WebApi.UnitTest.Controller
 			// assert
 			var createdResult = Assert.IsType<CreatedAtRouteResult>(result.Result);
 			Assert.Equal(applicationServiceModel, createdResult.Value);
-			Assert.Equal("Get", createdResult.RouteName);
+			Assert.Equal("GetApplication", createdResult.RouteName);
 			Assert.Equal(applicationServiceModel.ApplicationId, createdResult.RouteValues!["id"]);
 		}
 

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
@@ -13,6 +13,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 	public class ApplicationController : ControllerBase
 	{
+		private const string GetRouteName = "GetApplication";
 		private readonly IApplicationCreateCommand _applicationCreateCommand;
 		private readonly IApplicationGetQuery _applicationGetQuery;
 		private readonly IApplicationUpdateCommand _applicationUpdateCommand;
@@ -42,13 +43,13 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 
 			return result switch
 			{
-				CreateSuccessResult<ApplicationServiceModel> successResult => CreatedAtRoute("Get", new { id = successResult.Payload.ApplicationId }, successResult.Payload),
+				CreateSuccessResult<ApplicationServiceModel> successResult => CreatedAtRoute(GetRouteName, new { id = successResult.Payload.ApplicationId }, successResult.Payload),
 				CreateValidationErrorResult<ApplicationServiceModel> validationErrorResult => BadRequest(validationErrorResult.ValidationErrors),
 				_ => throw new NotImplementedException()
 			};
 		}
 
-		[HttpGet("{id}", Name = "Get")]
+		[HttpGet("{id}", Name = GetRouteName)]
 		public async Task<ActionResult<ApplicationServiceModel>> Get(int id)
 		{
 			var result = await _applicationGetQuery.Execute(id);

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ConversionAdvisoryBoardDecisionController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ConversionAdvisoryBoardDecisionController.cs
@@ -12,6 +12,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class ConversionAdvisoryBoardDecisionController : ControllerBase
 {
+	private const string GetRouteName = "GetProject";
 	private readonly IAdvisoryBoardDecisionCreateCommand _decisionCreateCommand;
 	private readonly IAdvisoryBoardDecisionUpdateCommand _decisionUpdateCommand;
 	private readonly IConversionAdvisoryBoardDecisionGetQuery _decisionGetQuery;
@@ -33,8 +34,8 @@ public class ConversionAdvisoryBoardDecisionController : ControllerBase
 		return result switch
 		{
 			CreateSuccessResult<ConversionAdvisoryBoardDecisionServiceModel> successResult => CreatedAtRoute(
-					HttpMethods.Get,
-					new { Id = successResult.Payload.AdvisoryBoardDecisionId },
+					GetRouteName,
+					new { projectId = successResult.Payload.AdvisoryBoardDecisionId },
 					successResult.Payload),
 			CreateValidationErrorResult<ConversionAdvisoryBoardDecisionServiceModel> validationErrorResult =>
 				new BadRequestObjectResult(validationErrorResult.ValidationErrors),
@@ -42,7 +43,7 @@ public class ConversionAdvisoryBoardDecisionController : ControllerBase
 		};
 	}
 
-	[HttpGet("{projectId:int}")]
+	[HttpGet("{projectId:int}", Name = GetRouteName)]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public async Task<ActionResult<ConversionAdvisoryBoardDecisionServiceModel>> GetByProjectId(int projectId)

--- a/Dfe.Academies.Academisation.WebApi/Controllers/LegacyProjectController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/LegacyProjectController.cs
@@ -1,0 +1,25 @@
+﻿using Dfe.Academies.Academisation.IService.Query;
+using Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.Academies.Academisation.WebApi.Controllers;
+
+[Route("legacy/project")]
+[ApiController]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+public class LegacyProjectController : ControllerBase
+{
+	private readonly ILegacyProjectGetQuery _legacyProjectGetQuery;
+
+	public LegacyProjectController(ILegacyProjectGetQuery legacyProjectGetQuery)
+	{
+		_legacyProjectGetQuery = legacyProjectGetQuery;
+	}
+
+	[HttpGet("{id}", Name = "GetLegacyProject")]
+	public async Task<ActionResult<LegacyProjectServiceModel>> Get(int id)
+	{
+		var result = await _legacyProjectGetQuery.Execute(id);
+		return result is null ? NotFound() : Ok(result);
+	}
+}

--- a/Dfe.Academies.Academisation.WebApi/Program.cs
+++ b/Dfe.Academies.Academisation.WebApi/Program.cs
@@ -1,11 +1,13 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Dfe.Academies.Academisation.Data;
 using Dfe.Academies.Academisation.Data.ApplicationAggregate;
 using Dfe.Academies.Academisation.Data.ConversionAdvisoryBoardDecisionAggregate;
+using Dfe.Academies.Academisation.Data.ProjectAggregate;
 using Dfe.Academies.Academisation.Domain.ApplicationAggregate;
 using Dfe.Academies.Academisation.Domain.ConversionAdvisoryBoardDecisionAggregate;
 using Dfe.Academies.Academisation.IData.ApplicationAggregate;
 using Dfe.Academies.Academisation.IData.ConversionAdvisoryBoardDecisionAggregate;
+using Dfe.Academies.Academisation.IData.ProjectAggregate;
 using Dfe.Academies.Academisation.IDomain.ApplicationAggregate;
 using Dfe.Academies.Academisation.IDomain.ConversionAdvisoryBoardDecisionAggregate;
 using Dfe.Academies.Academisation.IService.Commands.AdvisoryBoardDecision;
@@ -66,6 +68,8 @@ builder.Services.AddScoped<IApplicationListByUserQuery, ApplicationListByUserQue
 builder.Services.AddScoped<IConversionAdvisoryBoardDecisionGetQuery, ConversionAdvisoryBoardDecisionGetQuery>();
 builder.Services.AddScoped<IAdvisoryBoardDecisionGetDataByProjectIdQuery, AdvisoryBoardDecisionGetDataByProjectIdQuery>();
 builder.Services.AddScoped<IAdvisoryBoardDecisionGetDataByDecisionIdQuery, AdvisoryBoardDecisionGetDataByDecisionIdQuery>();
+builder.Services.AddScoped<ILegacyProjectGetQuery, LegacyProjectGetQuery>();
+builder.Services.AddScoped<IProjectGetDataQuery, ProjectGetDataQuery>();
 
 builder.Services.AddDbContext<AcademisationContext>(options => options
 	.UseSqlServer(builder.Configuration["AcademiesDatabaseConnectionString"],


### PR DESCRIPTION
Initial full stack code for Get Project. Have called it "Legacy" for now as I've copied and pasted the models from the Academies API, this gives us the flexibility to rename things in a future non-legacy version without breaking Manage a Conversion.

Data layer is faked for now, I thought I'd do that last so we don't have to churn the ef migrations if we rename things.

Also includes a bug fix for CreateProject which was using the wrong parameter names for CreateAtRoute (thank you @MartinWheelerMT for finding and fixing the bug!)