### PR TITLE
AB#105464 - API - Pre-support grant 

### DIFF
--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -54,10 +54,6 @@ public class ApplicationSchoolState : BaseEntity
 	public bool? PartOfPrioritySchoolsBuildingProgramme { get; set; }
 	public bool? PartOfBuildingSchoolsForFutureProgramme { get; set; }
 	// application pre-support grant
-
-	/// <summary>
-	/// either "To the school" or "To the trust the school is joining"
-	/// </summary>
 	public string? SupportGrantFundsPaidTo { get; set; }
 	public bool? ConfirmPaySupportGrantToSchool { get; set; }
 

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -53,7 +53,13 @@ public class ApplicationSchoolState : BaseEntity
 	public string? PartOfPfiSchemeType { get; set; }
 	public bool? PartOfPrioritySchoolsBuildingProgramme { get; set; }
 	public bool? PartOfBuildingSchoolsForFutureProgramme { get; set; }
+	// application pre-support grant
 
+	/// <summary>
+	/// either "To the school" or "To the trust the school is joining"
+	/// </summary>
+	public string? SupportGrantFundsPaidTo { get; set; }
+	public bool? ConfirmPaySupportGrantToSchool { get; set; }
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{
@@ -97,7 +103,9 @@ public class ApplicationSchoolState : BaseEntity
 			PartOfPfiScheme = applyingSchool.Details.LandAndBuildings.PartOfPfiScheme,
 			PartOfPfiSchemeType = applyingSchool.Details.LandAndBuildings.PartOfPfiSchemeType,
 			PartOfPrioritySchoolsBuildingProgramme = applyingSchool.Details.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme,
-			PartOfBuildingSchoolsForFutureProgramme = applyingSchool.Details.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme
+			PartOfBuildingSchoolsForFutureProgramme = applyingSchool.Details.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme,
+			SupportGrantFundsPaidTo = applyingSchool.Details.SchoolSupportGrantFundsPaidTo,
+			ConfirmPaySupportGrantToSchool = applyingSchool.Details.ConfirmPaySupportGrantToSchool
 		};
 	}
 
@@ -145,7 +153,9 @@ public class ApplicationSchoolState : BaseEntity
 			ProjectedPupilNumbersYear2 = ProjectedPupilNumbersYear2,
 			ProjectedPupilNumbersYear3 = ProjectedPupilNumbersYear3,
 			CapacityAssumptions = CapacityAssumptions,
-			CapacityPublishedAdmissionsNumber = CapacityPublishedAdmissionsNumber
+			CapacityPublishedAdmissionsNumber = CapacityPublishedAdmissionsNumber,
+			SchoolSupportGrantFundsPaidTo = SupportGrantFundsPaidTo,
+			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool
 		};
 	}
 }

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -54,7 +54,7 @@ public class ApplicationSchoolState : BaseEntity
 	public bool? PartOfPrioritySchoolsBuildingProgramme { get; set; }
 	public bool? PartOfBuildingSchoolsForFutureProgramme { get; set; }
 	// application pre-support grant
-	public string? SupportGrantFundsPaidTo { get; set; }
+	public PayFundsTo? SupportGrantFundsPaidTo { get; set; }
 	public bool? ConfirmPaySupportGrantToSchool { get; set; }
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)

--- a/Dfe.Academies.Academisation.Data/Migrations/20220908092640_ApplicationPreSupportGrant.Designer.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220908092640_ApplicationPreSupportGrant.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.Academies.Academisation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.Academies.Academisation.Data.Migrations
 {
     [DbContext(typeof(AcademisationContext))]
-    partial class AcademisationContextModelSnapshot : ModelSnapshot
+    [Migration("20220908092640_ApplicationPreSupportGrant")]
+    partial class ApplicationPreSupportGrant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -375,235 +377,6 @@ namespace Dfe.Academies.Academisation.Data.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("LegalRequirement", "academisation");
-                });
-
-            modelBuilder.Entity("Dfe.Academies.Academisation.Data.ProjectAggregate.ProjectState", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
-
-                    b.Property<string>("AcademyOrderRequired")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("AcademyTypeAndRoute")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("ApplicationReceivedDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("ApplicationReferenceNumber")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("AssignedDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Author")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("BaselineDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<decimal?>("CapitalCarryForwardAtEndMarchCurrentYear")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<decimal?>("CapitalCarryForwardAtEndMarchNextYear")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<string>("ClearedBy")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<decimal?>("ConversionSupportGrantAmount")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<string>("ConversionSupportGrantChangeReason")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
-
-                    b.Property<int?>("CurrentYearCapacity")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("CurrentYearPupilNumbers")
-                        .HasColumnType("int");
-
-                    b.Property<decimal?>("DistanceFromSchoolToTrustHeadquarters")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<string>("DistanceFromSchoolToTrustHeadquartersAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("EqualitiesImpactAssessmentConsidered")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("FinancialDeficit")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool?>("GeneralInformationSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<DateTime?>("HeadTeacherBoardDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("KeyStage2PerformanceAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("KeyStage4PerformanceAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("KeyStage5PerformanceAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int>("Laestab")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("LastModifiedOn")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("LocalAuthority")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("LocalAuthorityInformationTemplateComments")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("LocalAuthorityInformationTemplateLink")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("LocalAuthorityInformationTemplateReturnedDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<bool?>("LocalAuthorityInformationTemplateSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<DateTime?>("LocalAuthorityInformationTemplateSentDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("MemberOfParliamentName")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("MemberOfParliamentParty")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("NameOfTrust")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("NewAcademyUrn")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("OpeningDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("PartOfPfiScheme")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("PreviousHeadTeacherBoardDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("PreviousHeadTeacherBoardDateQuestion")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("PreviousHeadTeacherBoardLink")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("ProjectStatus")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<decimal?>("ProjectedRevenueBalanceAtEndMarchNextYear")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<DateTime?>("ProposedAcademyOpeningDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("PublishedAdmissionNumber")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("RationaleForProject")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("RationaleForTrust")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool?>("RationaleSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("RecommendationForProject")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<decimal?>("RevenueCarryForwardAtEndMarchCurrentYear")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<string>("RisksAndIssues")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool?>("RisksAndIssuesSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("SchoolAndTrustInformationSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("SchoolBudgetInformationAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool?>("SchoolBudgetInformationSectionComplete")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("SchoolName")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("SchoolPerformanceAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("SchoolPupilForecastsAdditionalInformation")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("SponsorName")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("SponsorReferenceNumber")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("TrustReferenceNumber")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UkPrn")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Upin")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int>("Urn")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Version")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("ViabilityIssues")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int?>("YearOneProjectedCapacity")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("YearOneProjectedPupilNumbers")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("YearThreeProjectedCapacity")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("YearThreeProjectedPupilNumbers")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("YearTwoProjectedCapacity")
-                        .HasColumnType("int");
-
-                    b.Property<int?>("YearTwoProjectedPupilNumbers")
-                        .HasColumnType("int");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Project", "academisation");
                 });
 
             modelBuilder.Entity("Dfe.Academies.Academisation.Data.ApplicationAggregate.ApplicationSchoolState", b =>

--- a/Dfe.Academies.Academisation.Data/Migrations/20220908092640_ApplicationPreSupportGrant.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220908092640_ApplicationPreSupportGrant.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Academies.Academisation.Data.Migrations
+{
+    public partial class ApplicationPreSupportGrant : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ConfirmPaySupportGrantToSchool",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SupportGrantFundsPaidTo",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConfirmPaySupportGrantToSchool",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SupportGrantFundsPaidTo",
+                schema: "academisation",
+                table: "ApplicationSchool");
+        }
+    }
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PreOpeningSupportGrantType.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PreOpeningSupportGrantType.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+
+namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+
+public enum PayFundsTo
+{
+	[Description("To the school")]
+	School = 1,
+	[Description("To the trust the school is joining")]
+	Trust = 2
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -32,6 +32,6 @@ public record SchoolDetails(
 	string? CapacityAssumptions = null,
 	int? CapacityPublishedAdmissionsNumber = null,
 	// application pre-support grant
-	string? SchoolSupportGrantFundsPaidTo = null,
+	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
 );

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -30,5 +30,8 @@ public record SchoolDetails(
 	int? ProjectedPupilNumbersYear2 = null,
 	int? ProjectedPupilNumbersYear3 = null,
 	string? CapacityAssumptions = null,
-	int? CapacityPublishedAdmissionsNumber = null
+	int? CapacityPublishedAdmissionsNumber = null,
+	// application pre-support grant
+	string? SchoolSupportGrantFundsPaidTo = null,
+	bool? ConfirmPaySupportGrantToSchool = null
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -31,7 +31,8 @@ public record ApplicationSchoolServiceModel(
 	int? ProjectedPupilNumbersYear2 = null,
 	int? ProjectedPupilNumbersYear3 = null,
 	string? SchoolCapacityAssumptions = null,
-	int? SchoolCapacityPublishedAdmissionsNumber = null
+	int? SchoolCapacityPublishedAdmissionsNumber = null,
 	// application pre-support grant
-	// TODO MR:-
+	string? SchoolSupportGrantFundsPaidTo = null,
+	bool? ConfirmPaySupportGrantToSchool = null
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Application;
+﻿using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+
+namespace Dfe.Academies.Academisation.IService.ServiceModels.Application;
 
 public record ApplicationSchoolServiceModel(
 	int Id,
@@ -33,6 +35,6 @@ public record ApplicationSchoolServiceModel(
 	string? SchoolCapacityAssumptions = null,
 	int? SchoolCapacityPublishedAdmissionsNumber = null,
 	// application pre-support grant
-	string? SchoolSupportGrantFundsPaidTo = null,
+	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ApplicationAggregate/LegacySchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ApplicationAggregate/LegacySchoolServiceModel.cs
@@ -32,7 +32,7 @@ public record LegacySchoolServiceModel(
 	bool? SchoolConversionChangeNamePlanned = null,
 	string? SchoolConversionProposedNewSchoolName = null,
 
-	// additional information
+	// additional details - data from current further information page below
 	string? SchoolAdSchoolContributionToTrust = null,
 	bool? SchoolOngoingSafeguardingInvestigations = null,
 	string? SchoolOngoingSafeguardingDetails = null,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -39,6 +39,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			ProjectedPupilNumbersYear3 = school.Details.ProjectedPupilNumbersYear3,
 			SchoolCapacityAssumptions = school.Details.CapacityAssumptions,
 			SchoolCapacityPublishedAdmissionsNumber = school.Details.CapacityPublishedAdmissionsNumber,
+			SchoolSupportGrantFundsPaidTo = school.Details.SchoolSupportGrantFundsPaidTo,
+			ConfirmPaySupportGrantToSchool = school.Details.ConfirmPaySupportGrantToSchool,
 		};
 	}
 
@@ -69,7 +71,9 @@ internal static class ApplicationSchoolServiceModelMapper
 			ProjectedPupilNumbersYear2 = serviceModel.ProjectedPupilNumbersYear2,
 			ProjectedPupilNumbersYear3 = serviceModel.ProjectedPupilNumbersYear3,
 			CapacityAssumptions = serviceModel.SchoolCapacityAssumptions,
-			CapacityPublishedAdmissionsNumber = serviceModel.SchoolCapacityPublishedAdmissionsNumber
+			CapacityPublishedAdmissionsNumber = serviceModel.SchoolCapacityPublishedAdmissionsNumber,
+			SchoolSupportGrantFundsPaidTo = serviceModel.SchoolSupportGrantFundsPaidTo,
+			ConfirmPaySupportGrantToSchool = serviceModel.ConfirmPaySupportGrantToSchool,
 		};
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -105,8 +105,8 @@ internal static class LegacySchoolServiceModelMapper
 			SchoolBuildLandPriorityBuildingProgramme = school.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme,
 			SchoolBuildLandFutureProgramme = school.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme,
 
-			// ToDo: pre-opening support grant
-			////SchoolSupportGrantFundsPaidTo = null, // either "To the school" or "To the trust the school is joining"
+			// pre-opening support grant
+			SchoolSupportGrantFundsPaidTo = school.SchoolSupportGrantFundsPaidTo , // either "To the school" or "To the trust the school is joining"
 
 			// ToDo: consultation details
 			////SchoolHasConsultedStakeholders = null,

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -106,7 +106,7 @@ internal static class LegacySchoolServiceModelMapper
 			SchoolBuildLandFutureProgramme = school.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme,
 
 			// pre-opening support grant
-			SchoolSupportGrantFundsPaidTo = school.SchoolSupportGrantFundsPaidTo , // either "To the school" or "To the trust the school is joining"
+			SchoolSupportGrantFundsPaidTo = MapType(school), // either "To the school" or "To the trust the school is joining"
 
 			// ToDo: consultation details
 			////SchoolHasConsultedStakeholders = null,
@@ -122,5 +122,15 @@ internal static class LegacySchoolServiceModelMapper
 		};
 
 		return serviceModel;
+	}
+
+	private static string MapType(SchoolDetails school)
+	{
+		return school.SchoolSupportGrantFundsPaidTo switch
+		{
+			PayFundsTo.School => "To the school",
+			PayFundsTo.Trust => "To the trust the school is joining",
+			_ => throw new NotImplementedException("Unrecognised PayFundsTo, has a new PayFundsTo been added recently?"),
+		};
 	}
 }


### PR DESCRIPTION
Adding pre-support grant onto GET & PUT endpoints as per this ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105464?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
'SchoolSupportGrantFundsPaidTo' property to be present in GET && PUT endpoint
'ConfirmPaySupportGrantToSchool' property to be present in GET && PUT endpoint
And, within 'ApplicationSchool' table in sip DB

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Run unit tests to ensure nothing broken
2. Run dotnet ef database update - to ensure new column created
3. run API to ensure new property is available on GET && PUT endpoints

## Prerequisites
n/a