### PR TITLE
105888 add additional info data storage

### DIFF
--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -85,8 +85,7 @@ public class ApplicationSchoolState : BaseEntity
 	public string? GoverningBodyConsentEvidenceDocumentLink { get; set; }
 	public bool? AdditionalInformationAdded { get; set; }
 	public string? AdditionalInformation { get; set; }
-	// TODO MR:- UI uses an enum A2CEqualityImpact
-	public bool? EqualitiesImpactAssessmentCompleted { get; set; }
+	public EqualityImpact? EqualitiesImpactAssessmentCompleted { get; set; }
 	public string? EqualitiesImpactAssessmentDetails { get; set; }
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -57,6 +57,33 @@ public class ApplicationSchoolState : BaseEntity
 	public PayFundsTo? SupportGrantFundsPaidTo { get; set; }
 	public bool? ConfirmPaySupportGrantToSchool { get; set; }
 
+	// additional information - for data storage - store them flat !
+	// TODO MR:- all below:-
+	//string? SchoolAdSchoolContributionToTrust = null,
+	//bool? SchoolOngoingSafeguardingInvestigations = null,
+	//string? SchoolOngoingSafeguardingDetails = null,
+	//bool? SchoolPartOfLaReorganizationPlan = null,
+	//string? SchoolLaReorganizationDetails = null,
+	//bool? SchoolPartOfLaClosurePlan = null,
+	//string? SchoolLaClosurePlanDetails = null,
+	//bool? SchoolFaithSchool = null,
+	//string? SchoolFaithSchoolDioceseName = null,
+	//string? DiocesePermissionEvidenceDocumentLink = null,
+	//bool? SchoolIsPartOfFederation = null,
+	//bool? SchoolIsSupportedByFoundation = null,
+	//string? SchoolSupportedFoundationBodyName = null,
+	//string? FoundationEvidenceDocumentLink = null,
+	//bool? SchoolHasSACREException = null,
+	//	DateTime? SchoolSACREExemptionEndDate = null,
+	//string? SchoolAdFeederSchools = null,
+	//string? GoverningBodyConsentEvidenceDocumentLink = null,
+	//bool? SchoolAdEqualitiesImpactAssessmentCompleted = null,
+	//string? SchoolAdEqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
+	//bool? SchoolAdInspectedButReportNotPublished = null,
+	//string? SchoolAdInspectedButReportNotPublishedExplain = null,
+	//bool? SchoolAdditionalInformationAdded = null,
+	//string? SchoolAdditionalInformation = null,
+
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{
 		return new()
@@ -101,7 +128,9 @@ public class ApplicationSchoolState : BaseEntity
 			PartOfPrioritySchoolsBuildingProgramme = applyingSchool.Details.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme,
 			PartOfBuildingSchoolsForFutureProgramme = applyingSchool.Details.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme,
 			SupportGrantFundsPaidTo = applyingSchool.Details.SchoolSupportGrantFundsPaidTo,
-			ConfirmPaySupportGrantToSchool = applyingSchool.Details.ConfirmPaySupportGrantToSchool
+			ConfirmPaySupportGrantToSchool = applyingSchool.Details.ConfirmPaySupportGrantToSchool,
+			// additional information
+			// TODO MR:-
 		};
 	}
 
@@ -151,7 +180,9 @@ public class ApplicationSchoolState : BaseEntity
 			CapacityAssumptions = CapacityAssumptions,
 			CapacityPublishedAdmissionsNumber = CapacityPublishedAdmissionsNumber,
 			SchoolSupportGrantFundsPaidTo = SupportGrantFundsPaidTo,
-			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool
+			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool,
+			// additional information
+			// TODO MR:-
 		};
 	}
 }

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -135,7 +135,36 @@ public class ApplicationSchoolState : BaseEntity
 			SupportGrantFundsPaidTo = applyingSchool.Details.SchoolSupportGrantFundsPaidTo,
 			ConfirmPaySupportGrantToSchool = applyingSchool.Details.ConfirmPaySupportGrantToSchool,
 			// additional information
-			// TODO MR:-
+			// Performance
+			InspectedButReportNotPublished = applyingSchool.Details.Performance.InspectedButReportNotPublished,
+			InspectedButReportNotPublishedExplain = applyingSchool.Details.Performance.InspectedButReportNotPublishedExplain,
+			OngoingSafeguardingInvestigations = applyingSchool.Details.Performance.OngoingSafeguardingInvestigations,
+			OngoingSafeguardingDetails = applyingSchool.Details.Performance.OngoingSafeguardingDetails,
+
+			// LocalAuthority
+			PartOfLaReorganizationPlan = applyingSchool.Details.LocalAuthority.PartOfLaReorganizationPlan,
+			LaReorganizationDetails = applyingSchool.Details.LocalAuthority.LaReorganizationDetails,
+			PartOfLaClosurePlan = applyingSchool.Details.LocalAuthority.PartOfLaClosurePlan,
+			LaClosurePlanDetails = applyingSchool.Details.LocalAuthority.LaClosurePlanDetails,
+			// PartnershipsAndAffliations
+			IsPartOfFederation = applyingSchool.Details.PartnershipsAndAffliations.IsPartOfFederation,
+			IsSupportedByFoundation = applyingSchool.Details.PartnershipsAndAffliations.IsSupportedByFoundation,
+			SupportedFoundationName = applyingSchool.Details.PartnershipsAndAffliations.SupportedFoundationName,
+			SupportedFoundationEvidenceDocumentLink = applyingSchool.Details.PartnershipsAndAffliations.SupportedFoundationEvidenceDocumentLink,
+			FeederSchools = applyingSchool.Details.PartnershipsAndAffliations.FeederSchools,
+			// religion
+			FaithSchool = applyingSchool.Details.ReligiousEducation.FaithSchool,
+			FaithSchoolDioceseName = applyingSchool.Details.ReligiousEducation.FaithSchoolDioceseName,
+			DiocesePermissionEvidenceDocumentLink = applyingSchool.Details.ReligiousEducation.DiocesePermissionEvidenceDocumentLink,
+			HasSACREException = applyingSchool.Details.ReligiousEducation.HasSACREException,
+			SACREExemptionEndDate = applyingSchool.Details.ReligiousEducation.SACREExemptionEndDate,
+			// other additional information
+			SchoolContributionToTrust = applyingSchool.Details.SchoolContributionToTrust,
+			GoverningBodyConsentEvidenceDocumentLink = applyingSchool.Details.GoverningBodyConsentEvidenceDocumentLink,
+			AdditionalInformationAdded = applyingSchool.Details.AdditionalInformationAdded,
+			AdditionalInformation = applyingSchool.Details.AdditionalInformation,
+			EqualitiesImpactAssessmentCompleted = applyingSchool.Details.EqualitiesImpactAssessmentCompleted, 
+			EqualitiesImpactAssessmentDetails = applyingSchool.Details.EqualitiesImpactAssessmentDetails,
 		};
 	}
 
@@ -158,7 +187,17 @@ public class ApplicationSchoolState : BaseEntity
 				PartOfPfiSchemeType = PartOfPfiSchemeType,
 				PartOfPrioritySchoolsBuildingProgramme = PartOfPrioritySchoolsBuildingProgramme,
 				PartOfBuildingSchoolsForFutureProgramme = PartOfBuildingSchoolsForFutureProgramme
-			})
+			},
+			new Performance{},
+			new LocalAuthority{},
+			new PartnershipsAndAffliations{},
+			new ReligiousEducation{},
+			SchoolContributionToTrust = SchoolContributionToTrust,
+			GoverningBodyConsentEvidenceDocumentLink = GoverningBodyConsentEvidenceDocumentLink,
+			AdditionalInformationAdded = AdditionalInformationAdded,
+			AdditionalInformation = AdditionalInformation,
+			EqualitiesImpactAssessmentCompleted = EqualitiesImpactAssessmentCompleted,
+			EqualitiesImpactAssessmentDetails = EqualitiesImpactAssessmentDetails)
 		{
 			ContactRole = ContactRole,
 			ApproverContactEmail = ApproverContactEmail,
@@ -185,9 +224,7 @@ public class ApplicationSchoolState : BaseEntity
 			CapacityAssumptions = CapacityAssumptions,
 			CapacityPublishedAdmissionsNumber = CapacityPublishedAdmissionsNumber,
 			SchoolSupportGrantFundsPaidTo = SupportGrantFundsPaidTo,
-			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool,
-			// additional information
-			// TODO MR:-
+			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool
 		};
 	}
 }

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -58,31 +58,36 @@ public class ApplicationSchoolState : BaseEntity
 	public bool? ConfirmPaySupportGrantToSchool { get; set; }
 
 	// additional information - for data storage - store them flat !
-	// TODO MR:- all below:-
-	//string? SchoolAdSchoolContributionToTrust = null,
-	//bool? SchoolOngoingSafeguardingInvestigations = null,
-	//string? SchoolOngoingSafeguardingDetails = null,
-	//bool? SchoolPartOfLaReorganizationPlan = null,
-	//string? SchoolLaReorganizationDetails = null,
-	//bool? SchoolPartOfLaClosurePlan = null,
-	//string? SchoolLaClosurePlanDetails = null,
-	//bool? SchoolFaithSchool = null,
-	//string? SchoolFaithSchoolDioceseName = null,
-	//string? DiocesePermissionEvidenceDocumentLink = null,
-	//bool? SchoolIsPartOfFederation = null,
-	//bool? SchoolIsSupportedByFoundation = null,
-	//string? SchoolSupportedFoundationBodyName = null,
-	//string? FoundationEvidenceDocumentLink = null,
-	//bool? SchoolHasSACREException = null,
-	//	DateTime? SchoolSACREExemptionEndDate = null,
-	//string? SchoolAdFeederSchools = null,
-	//string? GoverningBodyConsentEvidenceDocumentLink = null,
-	//bool? SchoolAdEqualitiesImpactAssessmentCompleted = null,
-	//string? SchoolAdEqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
-	//bool? SchoolAdInspectedButReportNotPublished = null,
-	//string? SchoolAdInspectedButReportNotPublishedExplain = null,
-	//bool? SchoolAdditionalInformationAdded = null,
-	//string? SchoolAdditionalInformation = null,
+	// Performance
+	public bool? InspectedButReportNotPublished { get; set; }
+	public string? InspectedButReportNotPublishedExplain { get; set; }
+	public bool? OngoingSafeguardingInvestigations { get; set; }
+	public string? OngoingSafeguardingDetails { get; set; }
+	// LocalAuthority
+	public bool? PartOfLaReorganizationPlan { get; set; }
+	public string? LaReorganizationDetails { get; set; }
+	public bool? PartOfLaClosurePlan { get; set; }
+	public string? LaClosurePlanDetails { get; set; }
+	// PartnershipsAndAffliations
+	public bool? IsPartOfFederation { get; set; }
+	public bool? IsSupportedByFoundation { get; set; }
+	public string? SupportedFoundationName { get; set; }
+	public string? SupportedFoundationEvidenceDocumentLink { get; set; }
+	public string? FeederSchools { get; set; }
+	// religion
+	public bool? FaithSchool { get; set; }
+	public string? FaithSchoolDioceseName { get; set; }
+	public string? DiocesePermissionEvidenceDocumentLink { get; set; }
+	public bool? HasSACREException { get; set; }
+	public DateTime? SACREExemptionEndDate { get; set; }
+	// other additional information
+	public string? SchoolContributionToTrust { get; set; }
+	public string? GoverningBodyConsentEvidenceDocumentLink { get; set; }
+	public bool? AdditionalInformationAdded { get; set; }
+	public string? AdditionalInformation { get; set; }
+	// TODO MR:- UI uses an enum A2CEqualityImpact
+	public bool? EqualitiesImpactAssessmentCompleted { get; set; }
+	public string? EqualitiesImpactAssessmentDetails { get; set; }
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -188,17 +188,43 @@ public class ApplicationSchoolState : BaseEntity
 				PartOfPrioritySchoolsBuildingProgramme = PartOfPrioritySchoolsBuildingProgramme,
 				PartOfBuildingSchoolsForFutureProgramme = PartOfBuildingSchoolsForFutureProgramme
 			},
-			new Performance{},
-			new LocalAuthority{},
-			new PartnershipsAndAffliations{},
-			new ReligiousEducation{},
+			new Performance
+			{
+				InspectedButReportNotPublished = InspectedButReportNotPublished,
+				InspectedButReportNotPublishedExplain = InspectedButReportNotPublishedExplain,
+				OngoingSafeguardingDetails = OngoingSafeguardingDetails,
+				OngoingSafeguardingInvestigations = OngoingSafeguardingInvestigations
+			},
+			new LocalAuthority
+			{
+				PartOfLaReorganizationPlan = PartOfLaReorganizationPlan,
+				LaClosurePlanDetails = LaClosurePlanDetails,
+				PartOfLaClosurePlan = PartOfLaClosurePlan,
+				LaReorganizationDetails = LaReorganizationDetails
+			},
+			new PartnershipsAndAffliations
+			{
+				IsPartOfFederation = IsPartOfFederation,
+				IsSupportedByFoundation = IsSupportedByFoundation,
+				SupportedFoundationName = SupportedFoundationName,
+				SupportedFoundationEvidenceDocumentLink = SupportedFoundationEvidenceDocumentLink,
+				FeederSchools = FeederSchools
+			},
+			new ReligiousEducation
+			{
+				FaithSchool = FaithSchool,
+				FaithSchoolDioceseName = FaithSchoolDioceseName,
+				DiocesePermissionEvidenceDocumentLink = DiocesePermissionEvidenceDocumentLink,
+				HasSACREException = HasSACREException,
+				SACREExemptionEndDate = SACREExemptionEndDate
+			})
+		{
 			SchoolContributionToTrust = SchoolContributionToTrust,
 			GoverningBodyConsentEvidenceDocumentLink = GoverningBodyConsentEvidenceDocumentLink,
 			AdditionalInformationAdded = AdditionalInformationAdded,
 			AdditionalInformation = AdditionalInformation,
 			EqualitiesImpactAssessmentCompleted = EqualitiesImpactAssessmentCompleted,
-			EqualitiesImpactAssessmentDetails = EqualitiesImpactAssessmentDetails)
-		{
+			EqualitiesImpactAssessmentDetails = EqualitiesImpactAssessmentDetails,
 			ContactRole = ContactRole,
 			ApproverContactEmail = ApproverContactEmail,
 			ApproverContactName = ApproverContactName,

--- a/Dfe.Academies.Academisation.Data/Migrations/20220912094139_SchoolAdditionalInformation.Designer.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220912094139_SchoolAdditionalInformation.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.Academies.Academisation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.Academies.Academisation.Data.Migrations
 {
     [DbContext(typeof(AcademisationContext))]
-    partial class AcademisationContextModelSnapshot : ModelSnapshot
+    [Migration("20220912094139_SchoolAdditionalInformation")]
+    partial class SchoolAdditionalInformation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.Academies.Academisation.Data/Migrations/20220912094139_SchoolAdditionalInformation.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220912094139_SchoolAdditionalInformation.cs
@@ -1,0 +1,324 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Academies.Academisation.Data.Migrations
+{
+    public partial class SchoolAdditionalInformation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "SupportGrantFundsPaidTo",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AdditionalInformation",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "AdditionalInformationAdded",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiocesePermissionEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EqualitiesImpactAssessmentCompleted",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EqualitiesImpactAssessmentDetails",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "FaithSchool",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FaithSchoolDioceseName",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FeederSchools",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GoverningBodyConsentEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HasSACREException",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "InspectedButReportNotPublished",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InspectedButReportNotPublishedExplain",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPartOfFederation",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSupportedByFoundation",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LaClosurePlanDetails",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LaReorganizationDetails",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OngoingSafeguardingDetails",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "OngoingSafeguardingInvestigations",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PartOfLaClosurePlan",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PartOfLaReorganizationPlan",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SACREExemptionEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SchoolContributionToTrust",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SupportedFoundationEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SupportedFoundationName",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdditionalInformation",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "AdditionalInformationAdded",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "DiocesePermissionEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "EqualitiesImpactAssessmentCompleted",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "EqualitiesImpactAssessmentDetails",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "FaithSchool",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "FaithSchoolDioceseName",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "FeederSchools",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "GoverningBodyConsentEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "HasSACREException",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "InspectedButReportNotPublished",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "InspectedButReportNotPublishedExplain",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "IsPartOfFederation",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "IsSupportedByFoundation",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "LaClosurePlanDetails",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "LaReorganizationDetails",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "OngoingSafeguardingDetails",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "OngoingSafeguardingInvestigations",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PartOfLaClosurePlan",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PartOfLaReorganizationPlan",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SACREExemptionEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SchoolContributionToTrust",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SupportedFoundationEvidenceDocumentLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SupportedFoundationName",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SupportGrantFundsPaidTo",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/EqualityImpactType.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/EqualityImpactType.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+{
+	public enum EqualityImpact
+	{
+		[Description("Considered unlikely")]
+		ConsideredUnlikely,
+		[Description("Considered will not")]
+		ConsideredWillNot,
+		[Description("Not considered")]
+		NotConsidered
+	}
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/LocalAuthority.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/LocalAuthority.cs
@@ -1,0 +1,9 @@
+﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+{
+	public record LocalAuthority(
+		bool? PartOfLaReorganizationPlan = null,
+		string? LaReorganizationDetails = null,
+		bool? PartOfLaClosurePlan = null,
+		string? LaClosurePlanDetails = null
+		);
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
@@ -1,0 +1,6 @@
+﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+{
+	public record PartnershipsAndAffliations(
+		// TODO MR:- props as per V2 specification - part of additional info legacy model
+		);
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
@@ -3,7 +3,7 @@
 	public record PartnershipsAndAffliations(
 		bool? IsPartOfFederation = null,
 		bool? IsSupportedByFoundation = null,
-		string? SupportedFoundationBodyName = null,
+		string? SupportedFoundationName = null,
 		string? SupportedFoundationEvidenceDocumentLink = null,
 		string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
 		);

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/PartnershipsAndAffliations.cs
@@ -4,7 +4,7 @@
 		bool? IsPartOfFederation = null,
 		bool? IsSupportedByFoundation = null,
 		string? SupportedFoundationBodyName = null,
-		string? FoundationEvidenceDocumentLink = null,
-		string? FeederSchools = null
+		string? SupportedFoundationEvidenceDocumentLink = null,
+		string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
 		);
 }

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/Performance.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/Performance.cs
@@ -1,0 +1,10 @@
+﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+{
+	public record Performance(
+		// TODO MR:- props as per V2 specification - part of additional info legacy model
+		bool? SchoolOngoingSafeguardingInvestigations = null,
+		string? SchoolOngoingSafeguardingDetails = null,
+		bool? SchoolAdInspectedButReportNotPublished = null,
+		string? SchoolAdInspectedButReportNotPublishedExplain = null
+	);
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/ReligiousEducation.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/ReligiousEducation.cs
@@ -1,0 +1,12 @@
+﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+{
+	public record ReligiousEducation
+	(
+		// TODO MR:- props as per V2 specification - part of additional info legacy model
+		bool? SchoolFaithSchool = null,
+		string? SchoolFaithSchoolDioceseName = null,
+		string? DiocesePermissionEvidenceDocumentLink = null,
+		bool? SchoolHasSACREException = null,
+		DateTime? SchoolSACREExemptionEndDate = null
+	);
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -4,6 +4,14 @@ public record SchoolDetails(
 	int Urn,
 	string SchoolName,
 	LandAndBuildings LandAndBuildings,
+	// additional information - split out
+	Performance Performance,
+	PartnershipsAndAffliations PartnershipsAndAffliations,
+	ReligiousEducation ReligiousEducation,
+	// TODO MR:- UI uses an enum A2CEqualityImpact
+	bool? EqualitiesImpactAssessmentCompleted = null,
+	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
+	// TODO MR:- Local auth questions in UI
 	// contact details
 	string? ContactHeadName = null,
 	string? ContactHeadEmail = null,
@@ -34,9 +42,4 @@ public record SchoolDetails(
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
-// additional information
-// TODO MR:- add in 3 new seperate objects
-//PartnershipsAndAffliations
-//Performance
-//ReligiousEducation
 );

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -34,4 +34,9 @@ public record SchoolDetails(
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
+// additional information
+// TODO MR:- add in 3 new seperate objects
+//PartnershipsAndAffliations
+//Performance
+//ReligiousEducation
 );

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -6,12 +6,16 @@ public record SchoolDetails(
 	LandAndBuildings LandAndBuildings,
 	// additional information - split out
 	Performance Performance,
+	LocalAuthority LocalAuthority,
 	PartnershipsAndAffliations PartnershipsAndAffliations,
 	ReligiousEducation ReligiousEducation,
+	string? SchoolContributionToTrust = null,
+	string? GoverningBodyConsentEvidenceDocumentLink = null,
+	bool? AdditionalInformationAdded = null,
+	string? AdditionalInformation = null,
 	// TODO MR:- UI uses an enum A2CEqualityImpact
 	bool? EqualitiesImpactAssessmentCompleted = null,
 	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
-	// TODO MR:- Local auth questions in UI
 	// contact details
 	string? ContactHeadName = null,
 	string? ContactHeadEmail = null,

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -13,9 +13,8 @@ public record SchoolDetails(
 	string? GoverningBodyConsentEvidenceDocumentLink = null,
 	bool? AdditionalInformationAdded = null,
 	string? AdditionalInformation = null,
-	// TODO MR:- UI uses an enum A2CEqualityImpact
-	bool? EqualitiesImpactAssessmentCompleted = null,
-	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
+	EqualityImpact? EqualitiesImpactAssessmentCompleted = null,
+	string? EqualitiesImpactAssessmentDetails = null, // there is no text input within the UI, just a radio with the enum values
 	// contact details
 	string? ContactHeadName = null,
 	string? ContactHeadEmail = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -7,6 +7,14 @@ public record ApplicationSchoolServiceModel(
 	int Urn,
 	string SchoolName,
 	LandAndBuildingsServiceModel LandAndBuildings,
+	// additional information - split up
+	PartnershipsAndAffliationsServiceModel PartnershipsAndAffliations,
+	PerformanceServiceModel Performance,
+	ReligiousEducationServiceModel ReligiousEducation,
+	// TODO MR:- UI uses an enum A2CEqualityImpact
+	bool? EqualitiesImpactAssessmentCompleted = null,
+	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
+	// TODO MR:- Local auth questions in UI
 	// contact details
 	string? SchoolConversionContactHeadName = null,
 	string? SchoolConversionContactHeadEmail = null,
@@ -37,9 +45,4 @@ public record ApplicationSchoolServiceModel(
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
-	// additional information
-	// TODO MR:- add in 3 new seperate objects
-	//PartnershipsAndAffliations
-	//Performance
-	//ReligiousEducation
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -37,4 +37,9 @@ public record ApplicationSchoolServiceModel(
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null
+	// additional information
+	// TODO MR:- add in 3 new seperate objects
+	//PartnershipsAndAffliations
+	//Performance
+	//ReligiousEducation
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -9,7 +9,7 @@ public record ApplicationSchoolServiceModel(
 	LandAndBuildingsServiceModel LandAndBuildings,
 	// additional information - split up
 	PerformanceServiceModel Performance,
-	LocalAuthority LocalAuthority,
+	LocalAuthorityServiceModel LocalAuthority,
 	PartnershipsAndAffliationsServiceModel PartnershipsAndAffliations,
 	ReligiousEducationServiceModel ReligiousEducation,
 	string? SchoolContributionToTrust = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -8,13 +8,17 @@ public record ApplicationSchoolServiceModel(
 	string SchoolName,
 	LandAndBuildingsServiceModel LandAndBuildings,
 	// additional information - split up
-	PartnershipsAndAffliationsServiceModel PartnershipsAndAffliations,
 	PerformanceServiceModel Performance,
+	LocalAuthority LocalAuthority,
+	PartnershipsAndAffliationsServiceModel PartnershipsAndAffliations,
 	ReligiousEducationServiceModel ReligiousEducation,
+	string? SchoolContributionToTrust = null,
+	string? GoverningBodyConsentEvidenceDocumentLink = null,
+	bool? AdditionalInformationAdded = null,
+	string? AdditionalInformation = null,
 	// TODO MR:- UI uses an enum A2CEqualityImpact
 	bool? EqualitiesImpactAssessmentCompleted = null,
 	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
-	// TODO MR:- Local auth questions in UI
 	// contact details
 	string? SchoolConversionContactHeadName = null,
 	string? SchoolConversionContactHeadEmail = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -16,8 +16,7 @@ public record ApplicationSchoolServiceModel(
 	string? GoverningBodyConsentEvidenceDocumentLink = null,
 	bool? AdditionalInformationAdded = null,
 	string? AdditionalInformation = null,
-	// TODO MR:- UI uses an enum A2CEqualityImpact
-	bool? EqualitiesImpactAssessmentCompleted = null,
+	EqualityImpact? EqualitiesImpactAssessmentCompleted = null,
 	string? EqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
 	// contact details
 	string? SchoolConversionContactHeadName = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/LocalAuthorityServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/LocalAuthorityServiceModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Application
+{
+	public record LocalAuthorityServiceModel(
+		bool? PartOfLaReorganizationPlan = null,
+		string? LaReorganizationDetails = null,
+		bool? PartOfLaClosurePlan = null,
+		string? LaClosurePlanDetails = null
+		);
+}

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
@@ -1,6 +1,6 @@
-﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Application
 {
-	public record PartnershipsAndAffliations(
+	public record PartnershipsAndAffliationsServiceModel(
 		bool? IsPartOfFederation = null,
 		bool? IsSupportedByFoundation = null,
 		string? SupportedFoundationBodyName = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
@@ -3,7 +3,7 @@
 	public record PartnershipsAndAffliationsServiceModel(
 		bool? IsPartOfFederation = null,
 		bool? IsSupportedByFoundation = null,
-		string? SupportedFoundationBodyName = null,
+		string? SupportedFoundationName = null,
 		string? SupportedFoundationEvidenceDocumentLink = null,
 		string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
 		);

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/PartnershipsAndAffliationsServiceModel.cs
@@ -4,7 +4,7 @@
 		bool? IsPartOfFederation = null,
 		bool? IsSupportedByFoundation = null,
 		string? SupportedFoundationBodyName = null,
-		string? FoundationEvidenceDocumentLink = null,
-		string? FeederSchools = null
+		string? SupportedFoundationEvidenceDocumentLink = null,
+		string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
 		);
 }

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/PerformanceServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/PerformanceServiceModel.cs
@@ -1,9 +1,9 @@
-﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Application
 {
-	public record Performance(
+	public record PerformanceServiceModel(
 		bool? InspectedButReportNotPublished = null,
 		string? InspectedButReportNotPublishedExplain = null, // provide inspection date && short summary in UI (1.5)
 		bool? OngoingSafeguardingInvestigations = null,
 		string? OngoingSafeguardingDetails = null
-	);
+		);
 }

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ReligiousEducationServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ReligiousEducationServiceModel.cs
@@ -1,11 +1,10 @@
-﻿namespace Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate
+﻿namespace Dfe.Academies.Academisation.IService.ServiceModels.Application
 {
-	public record ReligiousEducation
-	(
+	public record ReligiousEducationServiceModel(
 		bool? FaithSchool = null, // linked to a diocese yes/no?
 		string? FaithSchoolDioceseName = null,
 		string? DiocesePermissionEvidenceDocumentLink = null,
 		bool? HasSACREException = null,
 		DateTime? SACREExemptionEndDate = null
-	);
+		);
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -12,10 +12,19 @@ internal static class ApplicationSchoolServiceModelMapper
 			school.Id,
 			school.Details.Urn,
 			school.Details.SchoolName,
-			school.Details.LandAndBuildings.ToServiceModel()
+			school.Details.LandAndBuildings.ToServiceModel(),
+			school.Details.Performance.ToServiceModel(),
+			school.Details.LocalAuthority.ToServiceModel(),
+			school.Details.PartnershipsAndAffliations.ToServiceModel(),
+			school.Details.ReligiousEducation.ToServiceModel()
 		)
 		{
-			// TODO MR:- additional information other:-
+			SchoolContributionToTrust = school.Details.SchoolContributionToTrust,
+			GoverningBodyConsentEvidenceDocumentLink = school.Details.GoverningBodyConsentEvidenceDocumentLink,
+			AdditionalInformationAdded = school.Details.AdditionalInformationAdded,
+			AdditionalInformation = school.Details.AdditionalInformation,
+			EqualitiesImpactAssessmentCompleted = school.Details.EqualitiesImpactAssessmentCompleted,
+			EqualitiesImpactAssessmentDetails = school.Details.EqualitiesImpactAssessmentDetails,
 			SchoolConversionApproverContactEmail = school.Details.ApproverContactEmail,
 			SchoolConversionApproverContactName = school.Details.ApproverContactName,
 			SchoolConversionMainContactOtherEmail = school.Details.MainContactOtherEmail,
@@ -47,9 +56,22 @@ internal static class ApplicationSchoolServiceModelMapper
 
 	internal static SchoolDetails ToDomain(this ApplicationSchoolServiceModel serviceModel)
 	{
-		return new(serviceModel.Urn, serviceModel.SchoolName, serviceModel.LandAndBuildings.ToDomain())
+		return new(serviceModel.Urn, 
+			serviceModel.SchoolName, 
+			serviceModel.LandAndBuildings.ToDomain(),
+			serviceModel.Performance.ToDomain(),
+			serviceModel.LocalAuthority.ToDomain(),
+			serviceModel.PartnershipsAndAffliations.ToDomain(),
+			serviceModel.ReligiousEducation.ToDomain()
+			)
 		{
-			// TODO MR:- additional information other:-
+			
+			SchoolContributionToTrust = serviceModel.SchoolContributionToTrust,
+			GoverningBodyConsentEvidenceDocumentLink = serviceModel.GoverningBodyConsentEvidenceDocumentLink,
+			AdditionalInformationAdded = serviceModel.AdditionalInformationAdded,
+			AdditionalInformation = serviceModel.AdditionalInformation,
+			EqualitiesImpactAssessmentCompleted = serviceModel.EqualitiesImpactAssessmentCompleted,
+			EqualitiesImpactAssessmentDetails = serviceModel.EqualitiesImpactAssessmentDetails,
 			ApproverContactEmail = serviceModel.SchoolConversionApproverContactEmail,
 			ApproverContactName = serviceModel.SchoolConversionApproverContactName,
 			MainContactOtherTelephone = serviceModel.SchoolConversionMainContactOtherTelephone,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -15,6 +15,7 @@ internal static class ApplicationSchoolServiceModelMapper
 			school.Details.LandAndBuildings.ToServiceModel()
 		)
 		{
+			// TODO MR:- additional information other:-
 			SchoolConversionApproverContactEmail = school.Details.ApproverContactEmail,
 			SchoolConversionApproverContactName = school.Details.ApproverContactName,
 			SchoolConversionMainContactOtherEmail = school.Details.MainContactOtherEmail,
@@ -48,6 +49,7 @@ internal static class ApplicationSchoolServiceModelMapper
 	{
 		return new(serviceModel.Urn, serviceModel.SchoolName, serviceModel.LandAndBuildings.ToDomain())
 		{
+			// TODO MR:- additional information other:-
 			ApproverContactEmail = serviceModel.SchoolConversionApproverContactEmail,
 			ApproverContactName = serviceModel.SchoolConversionApproverContactName,
 			MainContactOtherTelephone = serviceModel.SchoolConversionMainContactOtherTelephone,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/LocalAuthorityModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/LocalAuthorityModelMapper.cs
@@ -7,20 +7,24 @@ namespace Dfe.Academies.Academisation.Service.Mappers.Application
 	{
 		internal static LocalAuthorityServiceModel ToServiceModel(this LocalAuthority localAuthority)
 		{
-			// TODO MR:-
-			//bool? PartOfLaReorganizationPlan = null,
-			//string? LaReorganizationDetails = null,
-			//bool? PartOfLaClosurePlan = null,
-			//string? LaClosurePlanDetails = null
+			return new LocalAuthorityServiceModel
+			{
+				PartOfLaReorganizationPlan = localAuthority.PartOfLaReorganizationPlan,
+				LaReorganizationDetails = localAuthority.LaReorganizationDetails,
+				PartOfLaClosurePlan = localAuthority.PartOfLaClosurePlan,
+				LaClosurePlanDetails = localAuthority.LaClosurePlanDetails
+			};
 		}
 
 		internal static LocalAuthority ToDomain(this LocalAuthorityServiceModel serviceModel)
 		{
-			// TODO MR:-
-			//bool? PartOfLaReorganizationPlan = null,
-			//string? LaReorganizationDetails = null,
-			//bool? PartOfLaClosurePlan = null,
-			//string? LaClosurePlanDetails = null
+			return new LocalAuthority
+			{
+				PartOfLaReorganizationPlan = serviceModel.PartOfLaReorganizationPlan,
+				LaReorganizationDetails = serviceModel.LaReorganizationDetails,
+				PartOfLaClosurePlan = serviceModel.PartOfLaClosurePlan,
+				LaClosurePlanDetails = serviceModel.LaClosurePlanDetails
+			};
 		}
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/LocalAuthorityModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/LocalAuthorityModelMapper.cs
@@ -1,0 +1,26 @@
+﻿using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using Dfe.Academies.Academisation.IService.ServiceModels.Application;
+
+namespace Dfe.Academies.Academisation.Service.Mappers.Application
+{
+	internal static class LocalAuthorityModelMapper
+	{
+		internal static LocalAuthorityServiceModel ToServiceModel(this LocalAuthority localAuthority)
+		{
+			// TODO MR:-
+			//bool? PartOfLaReorganizationPlan = null,
+			//string? LaReorganizationDetails = null,
+			//bool? PartOfLaClosurePlan = null,
+			//string? LaClosurePlanDetails = null
+		}
+
+		internal static LocalAuthority ToDomain(this LocalAuthorityServiceModel serviceModel)
+		{
+			// TODO MR:-
+			//bool? PartOfLaReorganizationPlan = null,
+			//string? LaReorganizationDetails = null,
+			//bool? PartOfLaClosurePlan = null,
+			//string? LaClosurePlanDetails = null
+		}
+	}
+}

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+{
+	internal static class PartnershipsAndAffliationsModelMapper
+	{
+		//TODO MR:-
+	}
+}

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
@@ -1,12 +1,23 @@
-﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+﻿using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using Dfe.Academies.Academisation.IService.ServiceModels.Application;
+
+namespace Dfe.Academies.Academisation.Service.Mappers.Application
 {
 	internal static class PartnershipsAndAffliationsModelMapper
 	{
-		//TODO MR:-
-		//bool? IsPartOfFederation = null,
-		//bool? IsSupportedByFoundation = null,
-		//string? SupportedFoundationBodyName = null,
-		//string? SupportedFoundationEvidenceDocumentLink = null,
-		//string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
+		internal static PartnershipsAndAffliationsServiceModel ToServiceModel(this PartnershipsAndAffliations partnershipsAndAffliationsModel)
+		{
+			//TODO MR:-
+			//bool? IsPartOfFederation = null,
+			//bool? IsSupportedByFoundation = null,
+			//string? SupportedFoundationBodyName = null,
+			//string? SupportedFoundationEvidenceDocumentLink = null,
+			//string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
+		}
+
+		internal static PartnershipsAndAffliations ToDomain(this PartnershipsAndAffliationsServiceModel serviceModel)
+		{
+			//TODO MR:-
+		}
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
@@ -3,5 +3,10 @@
 	internal static class PartnershipsAndAffliationsModelMapper
 	{
 		//TODO MR:-
+		//bool? IsPartOfFederation = null,
+		//bool? IsSupportedByFoundation = null,
+		//string? SupportedFoundationBodyName = null,
+		//string? SupportedFoundationEvidenceDocumentLink = null,
+		//string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PartnershipsAndAffliationsModelMapper.cs
@@ -7,17 +7,26 @@ namespace Dfe.Academies.Academisation.Service.Mappers.Application
 	{
 		internal static PartnershipsAndAffliationsServiceModel ToServiceModel(this PartnershipsAndAffliations partnershipsAndAffliationsModel)
 		{
-			//TODO MR:-
-			//bool? IsPartOfFederation = null,
-			//bool? IsSupportedByFoundation = null,
-			//string? SupportedFoundationBodyName = null,
-			//string? SupportedFoundationEvidenceDocumentLink = null,
-			//string? FeederSchools = null // just detail the top 5 - free text - don't select school Urn via UI
+			return new PartnershipsAndAffliationsServiceModel
+			{
+				IsPartOfFederation = partnershipsAndAffliationsModel.IsPartOfFederation,
+				IsSupportedByFoundation = partnershipsAndAffliationsModel.IsSupportedByFoundation,
+				SupportedFoundationName = partnershipsAndAffliationsModel.SupportedFoundationName,
+				SupportedFoundationEvidenceDocumentLink = partnershipsAndAffliationsModel.SupportedFoundationEvidenceDocumentLink,
+				FeederSchools = partnershipsAndAffliationsModel.FeederSchools
+			};
 		}
 
 		internal static PartnershipsAndAffliations ToDomain(this PartnershipsAndAffliationsServiceModel serviceModel)
 		{
-			//TODO MR:-
+			return new PartnershipsAndAffliations
+			{
+				IsPartOfFederation = serviceModel.IsPartOfFederation,
+				IsSupportedByFoundation = serviceModel.IsSupportedByFoundation,
+				SupportedFoundationName = serviceModel.SupportedFoundationName,
+				SupportedFoundationEvidenceDocumentLink = serviceModel.SupportedFoundationEvidenceDocumentLink,
+				FeederSchools = serviceModel.FeederSchools
+			};
 		}
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
@@ -1,11 +1,22 @@
-﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+﻿using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using Dfe.Academies.Academisation.IService.ServiceModels.Application;
+
+namespace Dfe.Academies.Academisation.Service.Mappers.Application
 {
 	internal static class PerformanceModelMapper
 	{
-		//TODO MR:-
-		//bool? InspectedButReportNotPublished = null,
-		//string? InspectedButReportNotPublishedExplain = null, // provide inspection date && short summary in UI (1.5)
-		//bool? OngoingSafeguardingInvestigations = null,
-		//string? OngoingSafeguardingDetails = null
+		internal static PerformanceServiceModel ToServiceModel(this Performance performance)
+		{
+			//TODO MR:-
+			//bool? InspectedButReportNotPublished = null,
+			//string? InspectedButReportNotPublishedExplain = null, // provide inspection date && short summary in UI (1.5)
+			//bool? OngoingSafeguardingInvestigations = null,
+			//string? OngoingSafeguardingDetails = null
+		}
+
+		internal static Performance ToDomain(this PerformanceServiceModel serviceModel)
+		{
+			//TODO MR:-
+		}
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
@@ -7,16 +7,24 @@ namespace Dfe.Academies.Academisation.Service.Mappers.Application
 	{
 		internal static PerformanceServiceModel ToServiceModel(this Performance performance)
 		{
-			//TODO MR:-
-			//bool? InspectedButReportNotPublished = null,
-			//string? InspectedButReportNotPublishedExplain = null, // provide inspection date && short summary in UI (1.5)
-			//bool? OngoingSafeguardingInvestigations = null,
-			//string? OngoingSafeguardingDetails = null
+			return new PerformanceServiceModel
+			{
+				InspectedButReportNotPublished = performance.InspectedButReportNotPublished,
+				InspectedButReportNotPublishedExplain = performance.InspectedButReportNotPublishedExplain,
+				OngoingSafeguardingInvestigations = performance.OngoingSafeguardingInvestigations,
+				OngoingSafeguardingDetails = performance.OngoingSafeguardingDetails
+			};
 		}
 
 		internal static Performance ToDomain(this PerformanceServiceModel serviceModel)
 		{
-			//TODO MR:-
+			return new Performance
+			{
+				InspectedButReportNotPublished = serviceModel.InspectedButReportNotPublished,
+				InspectedButReportNotPublishedExplain = serviceModel.InspectedButReportNotPublishedExplain,
+				OngoingSafeguardingInvestigations = serviceModel.OngoingSafeguardingInvestigations,
+				OngoingSafeguardingDetails = serviceModel.OngoingSafeguardingDetails
+			};
 		}
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
@@ -3,5 +3,9 @@
 	internal static class PerformanceModelMapper
 	{
 		//TODO MR:-
+		//bool? InspectedButReportNotPublished = null,
+		//string? InspectedButReportNotPublishedExplain = null, // provide inspection date && short summary in UI (1.5)
+		//bool? OngoingSafeguardingInvestigations = null,
+		//string? OngoingSafeguardingDetails = null
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/PerformanceModelMapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+{
+	internal static class PerformanceModelMapper
+	{
+		//TODO MR:-
+	}
+}

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
@@ -7,16 +7,25 @@ internal static class ReligiousEducationModelMapper
 {
 	internal static ReligiousEducationServiceModel ToServiceModel(this ReligiousEducation religiousEducation)
 	{
-		//TODO MR:-
-		//		bool? SchoolFaithSchool = null, // linked to a diocese yes/no?
-		//string? SchoolFaithSchoolDioceseName = null,
-		//string? DiocesePermissionEvidenceDocumentLink = null,
-		//bool? SchoolHasSACREException = null,
-		//	DateTime? SchoolSACREExemptionEndDate = null	
+		return new ReligiousEducationServiceModel
+		{
+			FaithSchool = religiousEducation.FaithSchool,
+			FaithSchoolDioceseName = religiousEducation.FaithSchoolDioceseName,
+			DiocesePermissionEvidenceDocumentLink = religiousEducation.DiocesePermissionEvidenceDocumentLink,
+			HasSACREException = religiousEducation.HasSACREException,
+			SACREExemptionEndDate = religiousEducation.SACREExemptionEndDate
+		};
 	}
 
 	internal static ReligiousEducation ToDomain(this ReligiousEducationServiceModel serviceModel)
 	{
-		//TODO MR:-
+		return new ReligiousEducation
+		{
+			FaithSchool = serviceModel.FaithSchool,
+			FaithSchoolDioceseName = serviceModel.FaithSchoolDioceseName,
+			DiocesePermissionEvidenceDocumentLink = serviceModel.DiocesePermissionEvidenceDocumentLink,
+			HasSACREException = serviceModel.HasSACREException,
+			SACREExemptionEndDate = serviceModel.SACREExemptionEndDate
+		};
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+{
+	internal static class ReligiousEducationModelMapper
+	{
+		//TODO MR:-	
+	}
+}

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
@@ -1,7 +1,14 @@
-﻿namespace Dfe.Academies.Academisation.Service.Mappers.Application
+﻿using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using Dfe.Academies.Academisation.IService.ServiceModels.Application;
+
+namespace Dfe.Academies.Academisation.Service.Mappers.Application;
+
+internal static class ReligiousEducationModelMapper
 {
-	internal static class ReligiousEducationModelMapper
-	{
-		//TODO MR:-	
-	}
+	//TODO MR:-
+	//		bool? SchoolFaithSchool = null, // linked to a diocese yes/no?
+	//string? SchoolFaithSchoolDioceseName = null,
+	//string? DiocesePermissionEvidenceDocumentLink = null,
+	//bool? SchoolHasSACREException = null,
+	//	DateTime? SchoolSACREExemptionEndDate = null	
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ReligiousEducationModelMapper.cs
@@ -5,10 +5,18 @@ namespace Dfe.Academies.Academisation.Service.Mappers.Application;
 
 internal static class ReligiousEducationModelMapper
 {
-	//TODO MR:-
-	//		bool? SchoolFaithSchool = null, // linked to a diocese yes/no?
-	//string? SchoolFaithSchoolDioceseName = null,
-	//string? DiocesePermissionEvidenceDocumentLink = null,
-	//bool? SchoolHasSACREException = null,
-	//	DateTime? SchoolSACREExemptionEndDate = null	
+	internal static ReligiousEducationServiceModel ToServiceModel(this ReligiousEducation religiousEducation)
+	{
+		//TODO MR:-
+		//		bool? SchoolFaithSchool = null, // linked to a diocese yes/no?
+		//string? SchoolFaithSchoolDioceseName = null,
+		//string? DiocesePermissionEvidenceDocumentLink = null,
+		//bool? SchoolHasSACREException = null,
+		//	DateTime? SchoolSACREExemptionEndDate = null	
+	}
+
+	internal static ReligiousEducation ToDomain(this ReligiousEducationServiceModel serviceModel)
+	{
+		//TODO MR:-
+	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -50,31 +50,36 @@ internal static class LegacySchoolServiceModelMapper
 			SchoolConversionChangeNamePlanned = school.ConversionChangeNamePlanned,
 			SchoolConversionProposedNewSchoolName = school.ProposedNewSchoolName,
 
-			// ToDo: additional information
-			////SchoolAdSchoolContributionToTrust = null,
-			////SchoolOngoingSafeguardingInvestigations = null,
-			////SchoolOngoingSafeguardingDetails = null,
-			////SchoolPartOfLaReorganizationPlan = null,
-			////SchoolLaReorganizationDetails = null,
-			////SchoolPartOfLaClosurePlan = null,
-			////SchoolLaClosurePlanDetails = null,
-			////SchoolFaithSchool = null,
-			////SchoolFaithSchoolDioceseName = null,
-			////DiocesePermissionEvidenceDocumentLink = null,
-			////SchoolIsPartOfFederation = null,
-			////SchoolIsSupportedByFoundation = null,
-			////SchoolSupportedFoundationBodyName = null,
-			////FoundationEvidenceDocumentLink = null,
-			////SchoolHasSACREException = null,
-			////SchoolSACREExemptionEndDate = null,
-			////SchoolAdFeederSchools = null,
-			////GoverningBodyConsentEvidenceDocumentLink = null,
-			////SchoolAdEqualitiesImpactAssessmentCompleted = null,
-			////SchoolAdEqualitiesImpactAssessmentDetails = null, // two possible very long proforma string? answers here - maybe this should be a bool
-			////SchoolAdInspectedButReportNotPublished = null,
-			////SchoolAdInspectedButReportNotPublishedExplain = null,
-			////SchoolAdditionalInformationAdded = null,
-			////SchoolAdditionalInformation = null,
+			// additional information
+			// Performance
+			SchoolAdInspectedButReportNotPublished = school.Performance.InspectedButReportNotPublished,
+			SchoolAdInspectedButReportNotPublishedExplain = school.Performance.InspectedButReportNotPublishedExplain,
+			SchoolOngoingSafeguardingInvestigations = school.Performance.OngoingSafeguardingInvestigations,
+			SchoolOngoingSafeguardingDetails = school.Performance.OngoingSafeguardingDetails,
+			// LocalAuthority
+			SchoolPartOfLaReorganizationPlan = school.LocalAuthority.PartOfLaReorganizationPlan,
+			SchoolLaReorganizationDetails = school.LocalAuthority.LaReorganizationDetails,
+			SchoolPartOfLaClosurePlan = school.LocalAuthority.PartOfLaClosurePlan,
+			SchoolLaClosurePlanDetails = school.LocalAuthority.LaClosurePlanDetails,
+			//PartnershipsAndAffliations
+			SchoolIsPartOfFederation = school.PartnershipsAndAffliations.IsPartOfFederation,
+			SchoolIsSupportedByFoundation = school.PartnershipsAndAffliations.IsSupportedByFoundation,
+			SchoolSupportedFoundationBodyName = school.PartnershipsAndAffliations.SupportedFoundationName,
+			FoundationEvidenceDocumentLink = school.PartnershipsAndAffliations.SupportedFoundationEvidenceDocumentLink,
+			SchoolAdFeederSchools = school.PartnershipsAndAffliations.FeederSchools,
+			// ReligiousEducation
+			SchoolFaithSchool = school.ReligiousEducation.FaithSchool,
+			SchoolFaithSchoolDioceseName = school.ReligiousEducation.FaithSchoolDioceseName,
+			DiocesePermissionEvidenceDocumentLink = school.ReligiousEducation.DiocesePermissionEvidenceDocumentLink,
+			SchoolHasSACREException = school.ReligiousEducation.HasSACREException,
+			SchoolSACREExemptionEndDate = school.ReligiousEducation.SACREExemptionEndDate,
+			// other additional information
+			SchoolAdSchoolContributionToTrust = school.SchoolContributionToTrust,
+			GoverningBodyConsentEvidenceDocumentLink = school.GoverningBodyConsentEvidenceDocumentLink,
+			SchoolAdditionalInformationAdded = school.AdditionalInformationAdded,
+			SchoolAdditionalInformation = school.AdditionalInformation,
+			SchoolAdEqualitiesImpactAssessmentCompleted = school.EqualitiesImpactAssessmentCompleted,
+			SchoolAdEqualitiesImpactAssessmentDetails = school.EqualitiesImpactAssessmentDetails, 
 
 			// ToDo: Finances
 			////PreviousFinancialYear = null,

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -78,7 +78,7 @@ internal static class LegacySchoolServiceModelMapper
 			GoverningBodyConsentEvidenceDocumentLink = school.GoverningBodyConsentEvidenceDocumentLink,
 			SchoolAdditionalInformationAdded = school.AdditionalInformationAdded,
 			SchoolAdditionalInformation = school.AdditionalInformation,
-			SchoolAdEqualitiesImpactAssessmentCompleted = school.EqualitiesImpactAssessmentCompleted,
+			SchoolAdEqualitiesImpactAssessmentCompleted = !string.IsNullOrWhiteSpace(school.EqualitiesImpactAssessmentDetails),
 			SchoolAdEqualitiesImpactAssessmentDetails = school.EqualitiesImpactAssessmentDetails, 
 
 			// ToDo: Finances


### PR DESCRIPTION
Adding additional information data capture onto GET & PUT endpoints as per this ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105888?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
All additional information properties to be present in GET && PUT endpoint
All additional information properties to be present in Legacy GET endpoint
All additional information properties table in sip DB

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Run unit tests to ensure nothing broken
2. Run dotnet ef database update - to ensure new column created
3. run API to ensure new properties are available on GET && PUT endpoints
4. run API to ensure new properties are available on legacy GET endpoint

## Prerequisites
n/a