### PR TITLE
105470 school finances next financial year

### DIFF
--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -98,8 +98,16 @@ public class ApplicationSchoolState : BaseEntity
 	public RevenueType? CurrentFinancialYearCapitalCarryForwardStatus { get; set; }
 	public string? CurrentFinancialYearCapitalCarryForwardExplained { get; set; }
 	public string? CurrentFinancialYearCapitalCarryForwardFileLink { get; set; }
-
-	// TODO:- next financial year
+	// next financial year
+	public DateTime? NextFinancialYearEndDate { get; set; }
+	public decimal? NextFinancialYearRevenue { get; set; }
+	public RevenueType? NextFinancialYearRevenueStatus { get; set; }
+	public string? NextFinancialYearRevenueStatusExplained { get; set; }
+	public string? NextFinancialYearRevenueStatusFileLink { get; set; }
+	public decimal? NextFinancialYearCapitalCarryForward { get; set; }
+	public RevenueType? NextFinancialYearCapitalCarryForwardStatus { get; set; }
+	public string? NextFinancialYearCapitalCarryForwardExplained { get; set; }
+	public string? NextFinancialYearCapitalCarryForwardFileLink { get; set; }
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{
@@ -188,8 +196,17 @@ public class ApplicationSchoolState : BaseEntity
 			CurrentFinancialYearCapitalCarryForward = applyingSchool.Details.CurrentFinancialYear.CapitalCarryForward,
 			CurrentFinancialYearCapitalCarryForwardStatus = applyingSchool.Details.CurrentFinancialYear.CapitalCarryForwardStatus,
 			CurrentFinancialYearCapitalCarryForwardExplained = applyingSchool.Details.CurrentFinancialYear.CapitalCarryForwardExplained,
-			CurrentFinancialYearCapitalCarryForwardFileLink = applyingSchool.Details.CurrentFinancialYear.CapitalCarryForwardFileLink
-			// next financial year - TODO
+			CurrentFinancialYearCapitalCarryForwardFileLink = applyingSchool.Details.CurrentFinancialYear.CapitalCarryForwardFileLink,
+			// next financial year
+			NextFinancialYearEndDate = applyingSchool.Details.NextFinancialYear.FinancialYearEndDate,
+			NextFinancialYearRevenue = applyingSchool.Details.NextFinancialYear.Revenue,
+			NextFinancialYearRevenueStatus = applyingSchool.Details.NextFinancialYear.RevenueStatus,
+			NextFinancialYearRevenueStatusExplained = applyingSchool.Details.NextFinancialYear.RevenueStatusExplained,
+			NextFinancialYearRevenueStatusFileLink = applyingSchool.Details.NextFinancialYear.RevenueStatusFileLink,
+			NextFinancialYearCapitalCarryForward = applyingSchool.Details.NextFinancialYear.CapitalCarryForward,
+			NextFinancialYearCapitalCarryForwardStatus = applyingSchool.Details.NextFinancialYear.CapitalCarryForwardStatus,
+			NextFinancialYearCapitalCarryForwardExplained = applyingSchool.Details.NextFinancialYear.CapitalCarryForwardExplained,
+			NextFinancialYearCapitalCarryForwardFileLink = applyingSchool.Details.NextFinancialYear.CapitalCarryForwardFileLink
 		};
 	}
 
@@ -244,6 +261,7 @@ public class ApplicationSchoolState : BaseEntity
 				SACREExemptionEndDate = SACREExemptionEndDate
 			},
 			// previous financial yr - TODO
+			// current financial year
 			new FinancialYear
 			{
 				FinancialYearEndDate = CurrentFinancialYearEndDate,
@@ -255,9 +273,21 @@ public class ApplicationSchoolState : BaseEntity
 				CapitalCarryForwardStatus = CurrentFinancialYearCapitalCarryForwardStatus,
 				CapitalCarryForwardExplained = CurrentFinancialYearCapitalCarryForwardExplained,
 				CapitalCarryForwardFileLink = CurrentFinancialYearCapitalCarryForwardFileLink
+			},
+			// next financial year 
+			new FinancialYear
+			{
+				FinancialYearEndDate = NextFinancialYearEndDate,
+				Revenue = NextFinancialYearRevenue,
+				RevenueStatus = NextFinancialYearRevenueStatus,
+				RevenueStatusExplained = NextFinancialYearRevenueStatusExplained,
+				RevenueStatusFileLink = NextFinancialYearRevenueStatusFileLink,
+				CapitalCarryForward = NextFinancialYearCapitalCarryForward,
+				CapitalCarryForwardStatus = NextFinancialYearCapitalCarryForwardStatus,
+				CapitalCarryForwardExplained = NextFinancialYearCapitalCarryForwardExplained,
+				CapitalCarryForwardFileLink = NextFinancialYearCapitalCarryForwardFileLink
 			}
-			// next financial year - TODO
-			)
+		)
 		{
 			SchoolContributionToTrust = SchoolContributionToTrust,
 			GoverningBodyConsentEvidenceDocumentLink = GoverningBodyConsentEvidenceDocumentLink,

--- a/Dfe.Academies.Academisation.Data/Migrations/20220912152802_SchoolNextFinancialYear.Designer.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220912152802_SchoolNextFinancialYear.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.Academies.Academisation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.Academies.Academisation.Data.Migrations
 {
     [DbContext(typeof(AcademisationContext))]
-    partial class AcademisationContextModelSnapshot : ModelSnapshot
+    [Migration("20220912152802_SchoolNextFinancialYear")]
+    partial class SchoolNextFinancialYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.Academies.Academisation.Data/Migrations/20220912152802_SchoolNextFinancialYear.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220912152802_SchoolNextFinancialYear.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Academies.Academisation.Data.Migrations
+{
+    public partial class SchoolNextFinancialYear : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "NextFinancialYearCapitalCarryForward",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NextFinancialYearCapitalCarryForwardExplained",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NextFinancialYearCapitalCarryForwardFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NextFinancialYearCapitalCarryForwardStatus",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextFinancialYearEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "NextFinancialYearRevenue",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NextFinancialYearRevenueStatus",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NextFinancialYearRevenueStatusExplained",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NextFinancialYearRevenueStatusFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearCapitalCarryForward",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearCapitalCarryForwardExplained",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearCapitalCarryForwardFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearCapitalCarryForwardStatus",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearRevenue",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearRevenueStatus",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearRevenueStatusExplained",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "NextFinancialYearRevenueStatusFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+        }
+    }
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -11,6 +11,7 @@ public record SchoolDetails(
 	ReligiousEducation ReligiousEducation,
 	// finances
 	FinancialYear CurrentFinancialYear,
+	FinancialYear NextFinancialYear,
 	string? SchoolContributionToTrust = null,
 	string? GoverningBodyConsentEvidenceDocumentLink = null,
 	bool? AdditionalInformationAdded = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -14,6 +14,7 @@ public record ApplicationSchoolServiceModel(
 	ReligiousEducationServiceModel ReligiousEducation,
 	// finances
 	FinancialYearServiceModel CurrentFinancialYear,
+	FinancialYearServiceModel NextFinancialYear,
 	string? SchoolContributionToTrust = null,
 	string? GoverningBodyConsentEvidenceDocumentLink = null,
 	bool? AdditionalInformationAdded = null,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -17,7 +17,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			school.Details.LocalAuthority.ToServiceModel(),
 			school.Details.PartnershipsAndAffliations.ToServiceModel(),
 			school.Details.ReligiousEducation.ToServiceModel(),
-			school.Details.CurrentFinancialYear.ToServiceModel()
+			school.Details.CurrentFinancialYear.ToServiceModel(),
+			school.Details.NextFinancialYear.ToServiceModel()
 		)
 		{
 			SchoolContributionToTrust = school.Details.SchoolContributionToTrust,
@@ -64,7 +65,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			serviceModel.LocalAuthority.ToDomain(),
 			serviceModel.PartnershipsAndAffliations.ToDomain(),
 			serviceModel.ReligiousEducation.ToDomain(),
-			serviceModel.CurrentFinancialYear.ToDomain()
+			serviceModel.CurrentFinancialYear.ToDomain(),
+			serviceModel.NextFinancialYear.ToDomain()
 			)
 		{
 			SchoolContributionToTrust = serviceModel.SchoolContributionToTrust,

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -92,7 +92,15 @@ internal static class LegacySchoolServiceModelMapper
 				CapitalIsDeficit = school.CurrentFinancialYear.CapitalCarryForwardStatus == RevenueType.Deficit,
 				CapitalStatusExplained = school.CurrentFinancialYear.CapitalCarryForwardExplained
 			},
-			////NextFinancialYear = school.NextFinancialYear,
+			NextFinancialYear = new LegacyFinancialYearServiceModel
+			{
+				FYEndDate = school.NextFinancialYear.FinancialYearEndDate,
+				RevenueCarryForward = school.NextFinancialYear.Revenue,
+				RevenueStatusExplained = school.NextFinancialYear.RevenueStatusExplained,
+				CapitalCarryForward = school.NextFinancialYear.CapitalCarryForward,
+				CapitalIsDeficit = school.NextFinancialYear.CapitalCarryForwardStatus == RevenueType.Deficit,
+				CapitalStatusExplained = school.NextFinancialYear.CapitalCarryForwardExplained
+			},
 			// ToDo: Finances - MK2
 			////FinanceOngoingInvestigations = null,
 			////SchoolFinancialInvestigationsExplain = null,


### PR DESCRIPTION
Adding next financial year data capture onto GET & PUT endpoints as per this ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105470?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
All additional next financial year properties to be present in GET && PUT endpoint
All additional next financial year properties to be present in Legacy GET endpoint
All additional next financial year properties table in sip DB

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Run unit tests to ensure nothing broken
2. Run dotnet ef database update - to ensure new column created
3. run API to ensure new properties are available on GET && PUT endpoints
4. run API to ensure new properties are available on legacy GET endpoint

## Prerequisites
n/a