### PR TITLE
AB#105472 - API - School Finances - Previous financial year 

### DIFF
--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -87,8 +87,17 @@ public class ApplicationSchoolState : BaseEntity
 	public string? AdditionalInformation { get; set; }
 	public EqualityImpact? EqualitiesImpactAssessmentCompleted { get; set; }
 	public string? EqualitiesImpactAssessmentDetails { get; set; }
-	// TODO:- previous financial year
-
+	// previous financial year
+	public DateTime? PreviousFinancialYearEndDate { get; set; }
+	public decimal? PreviousFinancialYearRevenue { get; set; }
+	public RevenueType? PreviousFinancialYearRevenueStatus { get; set; }
+	public string? PreviousFinancialYearRevenueStatusExplained { get; set; }
+	public string? PreviousFinancialYearRevenueStatusFileLink { get; set; }
+	public decimal? PreviousFinancialYearCapitalCarryForward { get; set; }
+	public RevenueType? PreviousFinancialYearCapitalCarryForwardStatus { get; set; }
+	public string? PreviousFinancialYearCapitalCarryForwardExplained { get; set; }
+	public string? PreviousFinancialYearCapitalCarryForwardFileLink { get; set; }
+	// current fin yr
 	public DateTime? CurrentFinancialYearEndDate { get; set; }
 	public decimal? CurrentFinancialYearRevenue { get; set; }
 	public RevenueType? CurrentFinancialYearRevenueStatus { get; set; }
@@ -185,8 +194,16 @@ public class ApplicationSchoolState : BaseEntity
 			AdditionalInformation = applyingSchool.Details.AdditionalInformation,
 			EqualitiesImpactAssessmentCompleted = applyingSchool.Details.EqualitiesImpactAssessmentCompleted, 
 			EqualitiesImpactAssessmentDetails = applyingSchool.Details.EqualitiesImpactAssessmentDetails,
-			// previous financial yr - TODO
-
+			// previous financial yr
+			PreviousFinancialYearEndDate = applyingSchool.Details.PreviousFinancialYear.FinancialYearEndDate,
+			PreviousFinancialYearRevenue = applyingSchool.Details.PreviousFinancialYear.Revenue,
+			PreviousFinancialYearRevenueStatus = applyingSchool.Details.PreviousFinancialYear.RevenueStatus,
+			PreviousFinancialYearRevenueStatusExplained = applyingSchool.Details.PreviousFinancialYear.RevenueStatusExplained,
+			PreviousFinancialYearRevenueStatusFileLink = applyingSchool.Details.PreviousFinancialYear.RevenueStatusFileLink,
+			PreviousFinancialYearCapitalCarryForward = applyingSchool.Details.PreviousFinancialYear.CapitalCarryForward,
+			PreviousFinancialYearCapitalCarryForwardStatus = applyingSchool.Details.PreviousFinancialYear.CapitalCarryForwardStatus,
+			PreviousFinancialYearCapitalCarryForwardExplained = applyingSchool.Details.PreviousFinancialYear.CapitalCarryForwardExplained,
+			PreviousFinancialYearCapitalCarryForwardFileLink = applyingSchool.Details.PreviousFinancialYear.CapitalCarryForwardFileLink,
 			// current financial yr
 			CurrentFinancialYearEndDate = applyingSchool.Details.CurrentFinancialYear.FinancialYearEndDate,
 			CurrentFinancialYearRevenue = applyingSchool.Details.CurrentFinancialYear.Revenue,
@@ -260,7 +277,19 @@ public class ApplicationSchoolState : BaseEntity
 				HasSACREException = HasSACREException,
 				SACREExemptionEndDate = SACREExemptionEndDate
 			},
-			// previous financial yr - TODO
+			// previous financial yr
+			new FinancialYear
+			{
+				FinancialYearEndDate = PreviousFinancialYearEndDate,
+				Revenue = PreviousFinancialYearRevenue,
+				RevenueStatus = PreviousFinancialYearRevenueStatus,
+				RevenueStatusExplained = PreviousFinancialYearRevenueStatusExplained,
+				RevenueStatusFileLink = PreviousFinancialYearRevenueStatusFileLink,
+				CapitalCarryForward = PreviousFinancialYearCapitalCarryForward,
+				CapitalCarryForwardStatus = PreviousFinancialYearCapitalCarryForwardStatus,
+				CapitalCarryForwardExplained = PreviousFinancialYearCapitalCarryForwardExplained,
+				CapitalCarryForwardFileLink = PreviousFinancialYearCapitalCarryForwardFileLink
+			},
 			// current financial year
 			new FinancialYear
 			{

--- a/Dfe.Academies.Academisation.Data/Migrations/20220913111614_SchoolPreviousFinancialYear.Designer.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220913111614_SchoolPreviousFinancialYear.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.Academies.Academisation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.Academies.Academisation.Data.Migrations
 {
     [DbContext(typeof(AcademisationContext))]
-    partial class AcademisationContextModelSnapshot : ModelSnapshot
+    [Migration("20220913111614_SchoolPreviousFinancialYear")]
+    partial class SchoolPreviousFinancialYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.Academies.Academisation.Data/Migrations/20220913111614_SchoolPreviousFinancialYear.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20220913111614_SchoolPreviousFinancialYear.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Academies.Academisation.Data.Migrations
+{
+    public partial class SchoolPreviousFinancialYear : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "PreviousFinancialYearCapitalCarryForward",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousFinancialYearCapitalCarryForwardExplained",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousFinancialYearCapitalCarryForwardFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreviousFinancialYearCapitalCarryForwardStatus",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PreviousFinancialYearEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PreviousFinancialYearRevenue",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreviousFinancialYearRevenueStatus",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousFinancialYearRevenueStatusExplained",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousFinancialYearRevenueStatusFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearCapitalCarryForward",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearCapitalCarryForwardExplained",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearCapitalCarryForwardFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearCapitalCarryForwardStatus",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearEndDate",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearRevenue",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearRevenueStatus",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearRevenueStatusExplained",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousFinancialYearRevenueStatusFileLink",
+                schema: "academisation",
+                table: "ApplicationSchool");
+        }
+    }
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -10,6 +10,7 @@ public record SchoolDetails(
 	PartnershipsAndAffliations PartnershipsAndAffliations,
 	ReligiousEducation ReligiousEducation,
 	// finances
+	FinancialYear PreviousFinancialYear,
 	FinancialYear CurrentFinancialYear,
 	FinancialYear NextFinancialYear,
 	string? SchoolContributionToTrust = null,

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -13,6 +13,7 @@ public record ApplicationSchoolServiceModel(
 	PartnershipsAndAffliationsServiceModel PartnershipsAndAffliations,
 	ReligiousEducationServiceModel ReligiousEducation,
 	// finances
+	FinancialYearServiceModel PreviousFinancialYear,
 	FinancialYearServiceModel CurrentFinancialYear,
 	FinancialYearServiceModel NextFinancialYear,
 	string? SchoolContributionToTrust = null,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -17,9 +17,9 @@ internal static class ApplicationSchoolServiceModelMapper
 			school.Details.LocalAuthority.ToServiceModel(),
 			school.Details.PartnershipsAndAffliations.ToServiceModel(),
 			school.Details.ReligiousEducation.ToServiceModel(),
+			school.Details.PreviousFinancialYear.ToServiceModel(),
 			school.Details.CurrentFinancialYear.ToServiceModel(),
-			school.Details.NextFinancialYear.ToServiceModel(),
-			school.Details.PreviousFinancialYear.ToServiceModel()
+			school.Details.NextFinancialYear.ToServiceModel()
 		)
 		{
 			SchoolContributionToTrust = school.Details.SchoolContributionToTrust,
@@ -66,10 +66,10 @@ internal static class ApplicationSchoolServiceModelMapper
 			serviceModel.LocalAuthority.ToDomain(),
 			serviceModel.PartnershipsAndAffliations.ToDomain(),
 			serviceModel.ReligiousEducation.ToDomain(),
+			serviceModel.PreviousFinancialYear.ToDomain(),
 			serviceModel.CurrentFinancialYear.ToDomain(),
-			serviceModel.NextFinancialYear.ToDomain(),
-			serviceModel.PreviousFinancialYear.ToDomain()
-			)
+			serviceModel.NextFinancialYear.ToDomain()
+		)
 		{
 			SchoolContributionToTrust = serviceModel.SchoolContributionToTrust,
 			GoverningBodyConsentEvidenceDocumentLink = serviceModel.GoverningBodyConsentEvidenceDocumentLink,

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -18,7 +18,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			school.Details.PartnershipsAndAffliations.ToServiceModel(),
 			school.Details.ReligiousEducation.ToServiceModel(),
 			school.Details.CurrentFinancialYear.ToServiceModel(),
-			school.Details.NextFinancialYear.ToServiceModel()
+			school.Details.NextFinancialYear.ToServiceModel(),
+			school.Details.PreviousFinancialYear.ToServiceModel()
 		)
 		{
 			SchoolContributionToTrust = school.Details.SchoolContributionToTrust,
@@ -66,7 +67,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			serviceModel.PartnershipsAndAffliations.ToDomain(),
 			serviceModel.ReligiousEducation.ToDomain(),
 			serviceModel.CurrentFinancialYear.ToDomain(),
-			serviceModel.NextFinancialYear.ToDomain()
+			serviceModel.NextFinancialYear.ToDomain(),
+			serviceModel.PreviousFinancialYear.ToDomain()
 			)
 		{
 			SchoolContributionToTrust = serviceModel.SchoolContributionToTrust,

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -80,9 +80,12 @@ internal static class LegacySchoolServiceModelMapper
 			SchoolAdditionalInformation = school.AdditionalInformation,
 			SchoolAdEqualitiesImpactAssessmentCompleted = !string.IsNullOrWhiteSpace(school.EqualitiesImpactAssessmentDetails),
 			SchoolAdEqualitiesImpactAssessmentDetails = school.EqualitiesImpactAssessmentDetails,
-
-			// ToDo: Finances
-			////PreviousFinancialYear = school.PreviousFinancialYear,
+			// Finances
+			PreviousFinancialYear = new LegacyFinancialYearServiceModel
+			{
+				// TODO :-
+				//school.PreviousFinancialYear,
+			}, 
 			CurrentFinancialYear = new LegacyFinancialYearServiceModel
 			{
 				FYEndDate = school.CurrentFinancialYear.FinancialYearEndDate,

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -83,8 +83,12 @@ internal static class LegacySchoolServiceModelMapper
 			// Finances
 			PreviousFinancialYear = new LegacyFinancialYearServiceModel
 			{
-				// TODO :-
-				//school.PreviousFinancialYear,
+				FYEndDate = school.PreviousFinancialYear.FinancialYearEndDate,
+				RevenueCarryForward = school.PreviousFinancialYear.Revenue,
+				RevenueStatusExplained = school.PreviousFinancialYear.RevenueStatusExplained,
+				CapitalCarryForward = school.PreviousFinancialYear.CapitalCarryForward,
+				CapitalIsDeficit = school.PreviousFinancialYear.CapitalCarryForwardStatus == RevenueType.Deficit,
+				CapitalStatusExplained = school.PreviousFinancialYear.CapitalCarryForwardExplained
 			}, 
 			CurrentFinancialYear = new LegacyFinancialYearServiceModel
 			{


### PR DESCRIPTION
Adding previous financial year data capture onto GET & PUT endpoints as per this ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105472?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
All additional previous financial year properties to be present in GET && PUT endpoint
All additional previous financial year properties to be present in Legacy GET endpoint
All additional previous financial year properties table in sip DB

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Run unit tests to ensure nothing broken
2. Run dotnet ef database update - to ensure new column created
3. run API to ensure new properties are available on GET && PUT endpoints
4. run API to ensure new properties are available on legacy GET endpoint

## Prerequisites
n/a