### PR TITLE
108119 add school consultation persistence

### DIFF
--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using Dfe.Academies.Academisation.Domain.ApplicationAggregate;
 using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
 using Dfe.Academies.Academisation.IDomain.ApplicationAggregate;
@@ -124,15 +123,13 @@ public class ApplicationSchoolState : BaseEntity
 	[ForeignKey("ApplicationSchoolId")]
 	public HashSet<LoanState> Loans { get; set; } = new();
 
-	// Finances Investigations
-	// TODO:-
+	// TODO:- Finances Investigations
 
 	// consultation details
 	public bool? SchoolHasConsultedStakeholders { get; set; }
 	public string? SchoolPlanToConsultStakeholders { get; set; }
 
-	// declaration
-	// TODO:-
+	// TODO:- declaration
 
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{
@@ -252,13 +249,11 @@ public class ApplicationSchoolState : BaseEntity
 				})
 				.ToList() ?? new List<LoanState>()),
 			// TODO:- leases
-			// Finances Investigations
-			// TODO:-
+			// TODO:- Finances Investigations
 			// consultation details
 			SchoolHasConsultedStakeholders = applyingSchool.Details.SchoolHasConsultedStakeholders,
 			SchoolPlanToConsultStakeholders = applyingSchool.Details.SchoolPlanToConsultStakeholders,
-			// declaration
-			// TODO:-
+			// TODO:- declaration
 		};
 	}
 

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -124,6 +124,16 @@ public class ApplicationSchoolState : BaseEntity
 	[ForeignKey("ApplicationSchoolId")]
 	public HashSet<LoanState> Loans { get; set; } = new();
 
+	// Finances Investigations
+	// TODO:-
+
+	// consultation details
+	public bool? SchoolHasConsultedStakeholders { get; set; }
+	public string? SchoolPlanToConsultStakeholders { get; set; }
+
+	// declaration
+	// TODO:-
+
 	public static ApplicationSchoolState MapFromDomain(ISchool applyingSchool)
 	{
 		return new()

--- a/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
+++ b/Dfe.Academies.Academisation.Data/ApplicationAggregate/ApplicationSchoolState.cs
@@ -240,7 +240,6 @@ public class ApplicationSchoolState : BaseEntity
 			NextFinancialYearCapitalCarryForwardStatus = applyingSchool.Details.NextFinancialYear?.CapitalCarryForwardStatus,
 			NextFinancialYearCapitalCarryForwardExplained = applyingSchool.Details.NextFinancialYear?.CapitalCarryForwardExplained,
 			NextFinancialYearCapitalCarryForwardFileLink = applyingSchool.Details.NextFinancialYear?.CapitalCarryForwardFileLink,
-			// TODO MR:- loans
 			Loans = new HashSet<LoanState>(applyingSchool.Loans
 				?.Select(e => new LoanState
 				{
@@ -251,7 +250,15 @@ public class ApplicationSchoolState : BaseEntity
 					InterestRate = e.Details.InterestRate,
 					Schedule = e.Details.Schedule
 				})
-				.ToList() ?? new List<LoanState>())
+				.ToList() ?? new List<LoanState>()),
+			// TODO:- leases
+			// Finances Investigations
+			// TODO:-
+			// consultation details
+			SchoolHasConsultedStakeholders = applyingSchool.Details.SchoolHasConsultedStakeholders,
+			SchoolPlanToConsultStakeholders = applyingSchool.Details.SchoolPlanToConsultStakeholders,
+			// declaration
+			// TODO:-
 		};
 	}
 
@@ -376,7 +383,9 @@ public class ApplicationSchoolState : BaseEntity
 			CapacityAssumptions = CapacityAssumptions,
 			CapacityPublishedAdmissionsNumber = CapacityPublishedAdmissionsNumber,
 			SchoolSupportGrantFundsPaidTo = SupportGrantFundsPaidTo,
-			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool
+			ConfirmPaySupportGrantToSchool = ConfirmPaySupportGrantToSchool,
+			SchoolHasConsultedStakeholders = SchoolHasConsultedStakeholders,
+			SchoolPlanToConsultStakeholders = SchoolPlanToConsultStakeholders
 		};
 
 		return new School(Id, schoolDetails, Loans.Select(n => n.MapToDomain()));

--- a/Dfe.Academies.Academisation.Data/Migrations/20221005092601_SchoolConsultation.Designer.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20221005092601_SchoolConsultation.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.Academies.Academisation.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.Academies.Academisation.Data.Migrations
 {
     [DbContext(typeof(AcademisationContext))]
-    partial class AcademisationContextModelSnapshot : ModelSnapshot
+    [Migration("20221005092601_SchoolConsultation")]
+    partial class SchoolConsultation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.Academies.Academisation.Data/Migrations/20221005092601_SchoolConsultation.cs
+++ b/Dfe.Academies.Academisation.Data/Migrations/20221005092601_SchoolConsultation.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Academies.Academisation.Data.Migrations
+{
+    public partial class SchoolConsultation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SchoolHasConsultedStakeholders",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SchoolPlanToConsultStakeholders",
+                schema: "academisation",
+                table: "ApplicationSchool",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SchoolHasConsultedStakeholders",
+                schema: "academisation",
+                table: "ApplicationSchool");
+
+            migrationBuilder.DropColumn(
+                name: "SchoolPlanToConsultStakeholders",
+                schema: "academisation",
+                table: "ApplicationSchool");
+        }
+    }
+}

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -48,5 +48,7 @@ public record SchoolDetails(
 	int? CapacityPublishedAdmissionsNumber = null,
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
-	bool? ConfirmPaySupportGrantToSchool = null
+	bool? ConfirmPaySupportGrantToSchool = null,
+	bool? SchoolHasConsultedStakeholders = null,
+	string? SchoolPlanToConsultStakeholders = null
 );

--- a/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ApplicationAggregate/SchoolDetails.cs
@@ -49,6 +49,11 @@ public record SchoolDetails(
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
 	bool? ConfirmPaySupportGrantToSchool = null,
+	// consultation details
 	bool? SchoolHasConsultedStakeholders = null,
 	string? SchoolPlanToConsultStakeholders = null
+// Finances Investigations
+// TODO:-
+// declaration
+// TODO:-
 );

--- a/Dfe.Academies.Academisation.Domain/ApplicationAggregate/School.cs
+++ b/Dfe.Academies.Academisation.Domain/ApplicationAggregate/School.cs
@@ -25,5 +25,5 @@ public class School : ISchool
 	// leases & loans
 	public IReadOnlyCollection<ILoan> Loans => _loans.AsReadOnly();
 
-	// TODO MR:- leases
+	// TODO:- leases
 }

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Application/ApplicationSchoolServiceModel.cs
@@ -53,5 +53,12 @@ public record ApplicationSchoolServiceModel(
 	int? SchoolCapacityPublishedAdmissionsNumber = null,
 	// application pre-support grant
 	PayFundsTo? SchoolSupportGrantFundsPaidTo = null,
-	bool? ConfirmPaySupportGrantToSchool = null
+	bool? ConfirmPaySupportGrantToSchool = null,
+	// consultation details
+	bool? SchoolHasConsultedStakeholders = null,
+	string? SchoolPlanToConsultStakeholders = null
+// Finances Investigations
+// TODO:-
+// declaration
+// TODO:-
 );

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ApplicationAggregate/LegacySchoolServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ApplicationAggregate/LegacySchoolServiceModel.cs
@@ -96,8 +96,8 @@ public record LegacySchoolServiceModel(
 
 	// declaration
 	// two questions from the application form would be easy to mix up here
-	// 1. I agree with all of these statements, and belive that the facts stated in this application are true (summary page)
-	// 2. The information in this application is true to the best of my kowledge (actual question)
+	// 1. I agree with all of these statements, and believe that the facts stated in this application are true (summary page)
+	// 2. The information in this application is true to the best of my knowledge (actual question)
 	bool? DeclarationBodyAgree = null,
 	bool? DeclarationIAmTheChairOrHeadteacher = null,
 	string? DeclarationSignedByName = null

--- a/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Application/ApplicationSchoolServiceModelMapper.cs
@@ -56,6 +56,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			SchoolCapacityPublishedAdmissionsNumber = school.Details.CapacityPublishedAdmissionsNumber,
 			SchoolSupportGrantFundsPaidTo = school.Details.SchoolSupportGrantFundsPaidTo,
 			ConfirmPaySupportGrantToSchool = school.Details.ConfirmPaySupportGrantToSchool,
+			SchoolHasConsultedStakeholders = school.Details.SchoolHasConsultedStakeholders,
+			SchoolPlanToConsultStakeholders = school.Details.SchoolPlanToConsultStakeholders,
 		};
 	}
 
@@ -106,6 +108,8 @@ internal static class ApplicationSchoolServiceModelMapper
 			CapacityPublishedAdmissionsNumber = serviceModel.SchoolCapacityPublishedAdmissionsNumber,
 			SchoolSupportGrantFundsPaidTo = serviceModel.SchoolSupportGrantFundsPaidTo,
 			ConfirmPaySupportGrantToSchool = serviceModel.ConfirmPaySupportGrantToSchool,
+			SchoolHasConsultedStakeholders = serviceModel.SchoolHasConsultedStakeholders,
+			SchoolPlanToConsultStakeholders = serviceModel.SchoolPlanToConsultStakeholders
 		};
 	}
 }

--- a/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/Legacy/ApplicationAggregate/LegacySchoolServiceModelMapper.cs
@@ -124,10 +124,10 @@ internal static class LegacySchoolServiceModelMapper
 				CapitalIsDeficit = school.NextFinancialYear.CapitalCarryForwardStatus == RevenueType.Deficit,
 				CapitalStatusExplained = school.NextFinancialYear.CapitalCarryForwardExplained
 			},
-			// ToDo: Finances - MK2
-			////FinanceOngoingInvestigations = null,
-			////SchoolFinancialInvestigationsExplain = null,
-			////SchoolFinancialInvestigationsTrustAware = null,
+			// TODO:- Finances Investigations
+			////FinanceOngoingInvestigations = school.,
+			////SchoolFinancialInvestigationsExplain = school.,
+			////SchoolFinancialInvestigationsTrustAware = school.,
 
 			// future pupil numbers
 			ProjectedPupilNumbersYear1 = school.ProjectedPupilNumbersYear1,
@@ -153,17 +153,17 @@ internal static class LegacySchoolServiceModelMapper
 			// pre-opening support grant
 			SchoolSupportGrantFundsPaidTo = MapType(school), // either "To the school" or "To the trust the school is joining"
 
-			// ToDo: consultation details
-			////SchoolHasConsultedStakeholders = null,
-			////SchoolPlanToConsultStakeholders = null,
+			// consultation details
+			SchoolHasConsultedStakeholders = school.SchoolHasConsultedStakeholders,
+			SchoolPlanToConsultStakeholders = school.SchoolPlanToConsultStakeholders,
 
-			// ToDo: declaration
+			// TODO:- declaration
 			// two questions from the application form would be easy to mix up here
 			// 1. I agree with all of these statements, and belive that the facts stated in this application are true (summary page)
 			// 2. The information in this application is true to the best of my kowledge (actual question)
-			////DeclarationBodyAgree = null,
-			////DeclarationIAmTheChairOrHeadteacher = null,
-			////DeclarationSignedByName = null
+			////DeclarationBodyAgree = school.,
+			////DeclarationIAmTheChairOrHeadteacher = school.,
+			////DeclarationSignedByName = school.
 		};
 
 		return serviceModel;


### PR DESCRIPTION
Ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108119?McasTsid=26110

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Exposing 2 new JSON properties:-
      "schoolHasConsultedStakeholders": true,
      "schoolPlanToConsultStakeholders": "string"

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Go to put endpoint confirm new JSON properties
2. go to get endpoint confirm new JSON properties
3. Confirm new columns created in database

## Prerequisites
n/a