### PR TITLE
remove response headers if API is ever run in IIS / Azure App service directly

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/ActionResults/InternalServerErrorObjectResult.cs
+++ b/Dfe.Academies.Academisation.WebApi/ActionResults/InternalServerErrorObjectResult.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.Academies.Academisation.WebApi.ActionResults
 {

--- a/Dfe.Academies.Academisation.WebApi/AutoMapper/AutoMapperProfile.cs
+++ b/Dfe.Academies.Academisation.WebApi/AutoMapper/AutoMapperProfile.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AutoMapper;
+﻿using AutoMapper;
 using Dfe.Academies.Academisation.Service.AutoMapper;
 
 namespace Dfe.Academies.Academisation.WebApi.AutoMapper

--- a/Dfe.Academies.Academisation.WebApi/AutoMapper/AutoMapperSetup.cs
+++ b/Dfe.Academies.Academisation.WebApi/AutoMapper/AutoMapperSetup.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using AutoMapper;
 using Dfe.Academies.Academisation.Data.ApplicationAggregate;
 using Dfe.Academies.Academisation.Domain.ApplicationAggregate.Trusts;
@@ -14,7 +9,8 @@ namespace Dfe.Academies.Academisation.Service.AutoMapper;
 
 public static class AutoMapperSetup
 {
-	public static void AddMappings(Profile profile) {
+	public static void AddMappings(Profile profile)
+	{
 
 		Guard.Against.NullOrEmpty(nameof(profile));
 

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using Dfe.Academies.Academisation.Core;
-using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+﻿using Dfe.Academies.Academisation.Core;
 using Dfe.Academies.Academisation.IService.Commands.AdvisoryBoardDecision;
 using Dfe.Academies.Academisation.IService.Commands.Application;
 using Dfe.Academies.Academisation.IService.Query;

--- a/Dfe.Academies.Academisation.WebApi/Filters/HttpGlobalExceptionFilter.cs
+++ b/Dfe.Academies.Academisation.WebApi/Filters/HttpGlobalExceptionFilter.cs
@@ -1,7 +1,6 @@
-﻿using Dfe.Academies.Academisation.WebApi.ActionResults;
+﻿using System.Net;
+using Dfe.Academies.Academisation.WebApi.ActionResults;
 using Microsoft.AspNetCore.Mvc.Filters;
-
-using System.Net;
 using IHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
 
 namespace Dfe.Academies.Academisation.WebApi.Filters
@@ -23,18 +22,18 @@ namespace Dfe.Academies.Academisation.WebApi.Filters
 				context.Exception,
 				context.Exception.Message);
 
-				var json = new JsonErrorResponse
-				{
-					Messages = new[] { "An error occurred.Try it again." }
-				};
+			var json = new JsonErrorResponse
+			{
+				Messages = new[] { "An error occurred.Try it again." }
+			};
 
-				if (env.IsDevelopment())
-				{
-					json.DeveloperMessage = context.Exception;
-				}
+			if (env.IsDevelopment())
+			{
+				json.DeveloperMessage = context.Exception;
+			}
 
-				context.Result =  new InternalServerErrorObjectResult(json);
-				context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+			context.Result = new InternalServerErrorObjectResult(json);
+			context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
 			context.ExceptionHandled = true;
 		}

--- a/Dfe.Academies.Academisation.WebApi/Middleware/AddCorrelationIdMiddleware.cs
+++ b/Dfe.Academies.Academisation.WebApi/Middleware/AddCorrelationIdMiddleware.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.Primitives;
-
-namespace Dfe.Academies.Academisation.WebApi.Middleware
+﻿namespace Dfe.Academies.Academisation.WebApi.Middleware
 {
 	public class AddCorrelationIdMiddleware
 	{
@@ -18,7 +16,7 @@ namespace Dfe.Academies.Academisation.WebApi.Middleware
 			if (httpContext.Request.Headers.TryGetValue(
 			CorrelationIdHeaderKey, out var correlationId))
 			{
-				_logger.LogInformation($"CorrelationId from Request Header:{ correlationId }");
+				_logger.LogInformation($"CorrelationId from Request Header:{correlationId}");
 
 			}
 			else
@@ -26,7 +24,7 @@ namespace Dfe.Academies.Academisation.WebApi.Middleware
 				correlationId = Guid.NewGuid().ToString();
 				httpContext.Request.Headers.Add(CorrelationIdHeaderKey,
 				correlationId);
-				_logger.LogInformation($"Generated CorrelationId:{ correlationId}");
+				_logger.LogInformation($"Generated CorrelationId:{correlationId}");
 
 			}
 			httpContext.Response.OnStarting(() =>

--- a/Dfe.Academies.Academisation.WebApi/Middleware/RequestLoggingMiddleware.cs
+++ b/Dfe.Academies.Academisation.WebApi/Middleware/RequestLoggingMiddleware.cs
@@ -1,9 +1,4 @@
-﻿using System.Net.Http;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
-
-namespace Dfe.Academies.Academisation.WebApi.Middleware
+﻿namespace Dfe.Academies.Academisation.WebApi.Middleware
 {
 	public class RequestLoggingMiddleware
 	{
@@ -20,7 +15,7 @@ namespace Dfe.Academies.Academisation.WebApi.Middleware
 		{
 			string? correlationId = null;
 
-			if(context.Request.Headers.TryGetValue(
+			if (context.Request.Headers.TryGetValue(
 			AddCorrelationIdMiddleware.CorrelationIdHeaderKey, out var headerCorrelationId))
 			{
 				correlationId = headerCorrelationId;

--- a/Dfe.Academies.Academisation.WebApi/Program.cs
+++ b/Dfe.Academies.Academisation.WebApi/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using System.Text.Json.Serialization;
 using Dfe.Academies.Academisation.Data;
 using Dfe.Academies.Academisation.Data.ApplicationAggregate;
 using Dfe.Academies.Academisation.Data.ConversionAdvisoryBoardDecisionAggregate;
@@ -35,7 +34,8 @@ using Newtonsoft.Json.Serialization;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
-	.AddControllers(x => {
+	.AddControllers(x =>
+	{
 		x.Filters.Add(typeof(HttpGlobalExceptionFilter));
 	})
 	.AddNewtonsoftJson(options =>
@@ -150,7 +150,8 @@ app.MapControllers();
 
 app.Run();
 
-public partial class Program {
+public partial class Program
+{
 	public static string AppName = GetAppName();
 
 	public static string GetAppName()

--- a/Dfe.Academies.Academisation.WebApi/web.config
+++ b/Dfe.Academies.Academisation.WebApi/web.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!-- To customize the asp.net core module uncomment and edit the following section. 
+  For more info see https://go.microsoft.com/fwlink/?linkid=838655 -->
+  <!--
+  <system.webServer>
+    <handlers>
+      <remove name="aspNetCore"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+  </system.webServer>
+  -->
+
+  <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By" />
+        <add name="X-Content-Type-Options" value="nosniff" />
+      </customHeaders>
+    </httpProtocol>
+    <security>
+      <requestFiltering removeServerHeader="true" />
+    </security>
+  </system.webServer>
+
+</configuration>


### PR DESCRIPTION
Tackle 3 OWASP top 10 issues:-
- removed X-Powered-By 
- remove - IIS from response headers
- The value of nosniff will prevent primarily old browsers from MIME-sniffing.
see:-
https://blog.elmah.io/the-asp-net-core-security-headers-guide/