### PR TITLE
Deploy to Test Azure Container Apps

### DIFF
--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -1,0 +1,58 @@
+name: Continuous delivery
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  set-test-release-version:
+    name: Set Test Release Version
+    environment: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.release-version.outputs.version}}
+    steps:
+      - id: release-version
+        run: echo "::set-output name=version::release-1"
+
+  build-and-push-image-test:
+    name: Build and push image test
+
+    runs-on: ubuntu-latest
+    needs: set-test-release-version
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{needs.set-test-release-version.outputs.version}}
+
+      - name: Azure Container Registry login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.TEST_AZURE_ACR_CLIENTID }}
+          password: ${{ secrets.TEST_AZURE_ACR_SECRET }}
+          registry: ${{ secrets.TEST_ACR_URL }}
+
+      - name: Prepare tags
+        id: prepare-tags
+        run: |
+          DOCKER_IMAGE=${{ secrets.TEST_ACR_URL }}/academies-academisation-api
+          VERSION=latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=sha-${GITHUB_SHA}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=deploy-version::${VERSION}
+
+      - name: Push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: ASPNET_IMAGE_TAG=6.0.9-bullseye-slim-amd64
+          push: true
+          tags: ${{ steps.prepare-tags.outputs.tags }}


### PR DESCRIPTION
* Adds a GitHub action to build and push a specific release (eg. tag/sha/branch) to the Test ACR
* Currently set to tag `release-1`