### PR TITLE
Add list of Key Vault users

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/azure/azapi" {
   version     = "1.0.0"
-  constraints = ">= 0.5.0, >= 1.0.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:UEarnWmn8kdWSjcPdFj/bl+wxxpjwxRhM0FjK4/IyIE=",
     "zh:01a33aaefe4d185e70d926103eeb0ac9fefeadf750f69c5977ead2ae02e0b038",
@@ -21,9 +21,28 @@ provider "registry.terraform.io/azure/azapi" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version = "2.29.0"
+  hashes = [
+    "h1:n/Dcv/K0oKDHj/vRImKlzB2DYY4Gafv7TarBNn5aRZw=",
+    "zh:049f0b90042679247ebe9ae8e4e7bbcadd0d8764a2d9f6b7c84b0985a0550da9",
+    "zh:0d1e0a64c36451b77a6208a02a586e4f39960adc1d2db867383adeafaaf170bb",
+    "zh:124a019672dcde52f98bc6f2160b764be92b1648b172e08d454a5e938e7d78fd",
+    "zh:1b7dae68749615039a3dd2fd00398f6a283eea79ae69843a7420da31937c14b9",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:3f119ac8244d58208e7e0ad24924ae7ea7e5b6f2b0049ddf79e9fbc13bbf4c5f",
+    "zh:59c8d53cf3a0c132fa4e1ee14358a4a1670af35c5a4ba4da8701cb6bce9b09fa",
+    "zh:5a4d0a6fe3f9d6e612e7bb1a4845c55efea906e09e4fd7b9883d67add27af1ab",
+    "zh:79c42325602cff91aabc8000fcece3f808b152b2e839c9add63c83cf60ed91fb",
+    "zh:a77b87f9fc87bb9fa892bb0a3fa695f3ad57dbd35831ead9dc8709bc5fc9f002",
+    "zh:ab5b1c823375aa5ee002081f72e28bd15cafecb47b546247b45fb3e165aa7bdb",
+    "zh:efa4091ed8f124d261b3771259f28ca70fd926096445c0d6457342cb2f72092d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.25.0"
-  constraints = ">= 3.20.0, >= 3.25.0"
+  constraints = ">= 3.25.0"
   hashes = [
     "h1:y0PfEHDqCTSkv3bQpwM+RPEDB8+76PqwuRLF0lB7vhw=",
     "zh:35ae77914a6280592a199a56c75a5f953cb5553f4416e50f4d4f47732eeb8d67",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -132,6 +132,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.29.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.25.0 |
 
 ## Modules
@@ -146,6 +147,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|------|
 | [azurerm_key_vault.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_secret.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
@@ -159,6 +161,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with aprivate endpoint within the virtual network | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
+| <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This ensures that tfvars are kept up to date in Key Vault. | `string` | n/a | yes |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,1 +1,7 @@
 data "azurerm_client_config" "current" {}
+
+data "azuread_user" "key_vault_access" {
+  for_each = local.key_vault_access_users
+
+  user_principal_name = each.value
+}

--- a/terraform/key-vault-tfvars-secrets.tf
+++ b/terraform/key-vault-tfvars-secrets.tf
@@ -5,23 +5,29 @@ resource "azurerm_key_vault" "tfvars" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
+  enable_rbac_authorization  = false
 
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
+  dynamic "access_policy" {
+    for_each = data.azuread_user.key_vault_access
 
-    key_permissions = [
-      "Create",
-      "Get",
-    ]
+    content {
+      tenant_id = data.azurerm_client_config.current.tenant_id
+      object_id = access_policy.value["object_id"]
 
-    secret_permissions = [
-      "Set",
-      "Get",
-      "Delete",
-      "Purge",
-      "Recover"
-    ]
+      key_permissions = [
+        "Create",
+        "Get",
+      ]
+
+      secret_permissions = [
+        "Set",
+        "Get",
+        "Delete",
+        "Purge",
+        "Recover",
+        "List",
+      ]
+    }
   }
 
   # It won't be possible to add/manage a network acl for this

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,5 +9,6 @@ locals {
   container_command                      = var.container_command
   container_secret_environment_variables = var.container_secret_environment_variables
   enable_mssql_database                  = var.enable_mssql_database
+  key_vault_access_users                 = toset(var.key_vault_access_users)
   tfvars_filename                        = var.tfvars_filename
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -10,3 +10,6 @@ container_command           = ["/bin/bash", "-c", "echo hello && sleep 86400"]
 container_environment_variables = {
   "ASPNETCORE_ENVIRONMENT" = "production"
 }
+key_vault_access_users = [
+  "someone_example.com#EXT#@tenantname.onmicrosoft.com",
+]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "environment" {
   type        = string
 }
 
+variable "key_vault_access_users" {
+  description = "List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform"
+  type        = list(string)
+}
+
 variable "tfvars_filename" {
   description = "tfvars filename. This ensures that tfvars are kept up to date in Key Vault."
   type        = string


### PR DESCRIPTION
* Allows providing a list of users that require access to the Key Vault tfvars secrets
* The values should be the User Principle Name found in AD