### PR TITLE
116121 Delete school from FAM application

### DIFF
--- a/Dfe.Academies.Academisation.Domain.UnitTest/ApplicationAggregate/ApplicationUpdateTests.cs
+++ b/Dfe.Academies.Academisation.Domain.UnitTest/ApplicationAggregate/ApplicationUpdateTests.cs
@@ -851,6 +851,55 @@ public class ApplicationUpdateTests
 		Assert.Equivalent(expected, subject);
 	}
 
+	[Fact]
+	public void FormMatDeleteSchool__SuccessReturned_Mutated()
+	{
+		// arrange
+		// arrange
+		Application subject = BuildApplication(ApplicationStatus.InProgress, 0);
+
+		var updateSchoolParameters = subject.Schools.Select(s => new UpdateSchoolParameter(
+			s.Id,
+			s.TrustBenefitDetails,
+			s.OfstedInspectionDetails,
+			s.SafeguardingDetails,
+			s.LocalAuthorityReorganisationDetails,
+			s.LocalAuthorityClosurePlanDetails,
+			s.DioceseName,
+			s.DioceseFolderIdentifier,
+			s.PartOfFederation,
+			s.FoundationTrustOrBodyName,
+			s.FoundationConsentFolderIdentifier,
+			s.ExemptionEndDate,
+			s.MainFeederSchools,
+			s.ResolutionConsentFolderIdentifier,
+			s.ProtectedCharacteristics,
+			s.FurtherInformation,
+			s.Details,
+			s.Loans.Select(l => new KeyValuePair<int, LoanDetails>(l.Id, new LoanDetails(l.Amount, l.Purpose, l.Provider, l.InterestRate, l.Schedule))).ToList(),
+			s.Leases.Select(l => new KeyValuePair<int, LeaseDetails>(l.Id, new LeaseDetails(l.LeaseTerm, l.RepaymentAmount, l.InterestRate, l.PaymentsToDate, l.Purpose, l.ValueOfAssets, l.ResponsibleForAssets))).ToList(),
+			s.HasLoans,
+			s.HasLeases)
+		).ToList();
+
+		var schoolDetailsToAdd = _fixture.Create<UpdateSchoolParameter>();
+		updateSchoolParameters.Add(schoolDetailsToAdd);
+
+		subject.Update(
+			subject.ApplicationType,
+			subject.ApplicationStatus,
+			subject.Contributors.ToDictionary(c => c.Id, c => c.Details),
+			updateSchoolParameters);
+
+		// act
+		var result = subject.DeleteSchool(schoolDetailsToAdd.SchoolDetails.Urn);
+
+		// assert
+		DfeAssert.CommandSuccess(result);
+		subject.Schools.Should().NotBeNull();
+		subject.Schools.Should().HaveCount(0);
+	}
+
 	private Application BuildApplication(ApplicationStatus applicationStatus, int numberOfSchools, ApplicationType? type = null)
 	{
 		var schools = new List<School>();

--- a/Dfe.Academies.Academisation.Domain/ApplicationAggregate/Application.cs
+++ b/Dfe.Academies.Academisation.Domain/ApplicationAggregate/Application.cs
@@ -305,6 +305,15 @@ public class Application : IApplication, IAggregateRoot
 		return new CommandSuccessResult();
 	}
 
+	public CommandResult DeleteSchool(int urn)
+	{
+		var school = _schools.FirstOrDefault(x => x.Details.Urn == urn);
+		if (school == null)  return new NotFoundCommandResult();
+		_schools.Remove(school);
+
+		return new CommandSuccessResult();
+	}
+
 	public CommandResult SetAdditionalDetails(
 		int schoolId,
 		string trustBenefitDetails, 

--- a/Dfe.Academies.Academisation.IDomain/ApplicationAggregate/IApplication.cs
+++ b/Dfe.Academies.Academisation.IDomain/ApplicationAggregate/IApplication.cs
@@ -53,4 +53,5 @@ public interface IApplication
 	CommandResult AddTrustKeyPerson(string name, DateTime dateOfBirth, string biography, IEnumerable<ITrustKeyPersonRole> roles);
 	CommandResult UpdateTrustKeyPerson(int keyPersonId, string name, DateTime dateOfBirth, string biography, IEnumerable<ITrustKeyPersonRole> roles);
 	CommandResult DeleteTrustKeyPerson(int keyPersonId);
+	CommandResult DeleteSchool(int urn);
 }

--- a/Dfe.Academies.Academisation.IService/Commands/Application/CreateTrustKeyPersonCommand.cs
+++ b/Dfe.Academies.Academisation.IService/Commands/Application/CreateTrustKeyPersonCommand.cs
@@ -6,7 +6,7 @@ using MediatR;
 
 namespace Dfe.Academies.Academisation.IService.Commands.Application
 {
-	public record AddTrustKeyPersonCommand(
+	public record CreateTrustKeyPersonCommand(
 		int ApplicationId,
 		IEnumerable<TrustKeyPersonRoleServiceModel> Roles,
 		string Name,

--- a/Dfe.Academies.Academisation.IService/Commands/Application/DeleteSchoolCommand.cs
+++ b/Dfe.Academies.Academisation.IService/Commands/Application/DeleteSchoolCommand.cs
@@ -1,0 +1,10 @@
+﻿using Dfe.Academies.Academisation.Core;
+using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using MediatR;
+
+namespace Dfe.Academies.Academisation.IService.Commands.Application
+{
+	public record DeleteSchoolCommand(
+		int ApplicationId,
+		int Urn) : IRequest<CommandResult>;
+}

--- a/Dfe.Academies.Academisation.Service/Commands/Application/CreateTrustKeyPersonCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/Application/CreateTrustKeyPersonCommandHandler.cs
@@ -11,18 +11,18 @@ using MediatR;
 
 namespace Dfe.Academies.Academisation.Service.Commands.Application
 {
-	public class AddTrustKeyPersonCommandHandler : IRequestHandler<AddTrustKeyPersonCommand, CommandResult>
+	public class CreateTrustKeyPersonCommandHandler : IRequestHandler<CreateTrustKeyPersonCommand, CommandResult>
 	{
 		private readonly IApplicationRepository _applicationRepository;
 		private readonly IMapper _mapper;
 
-		public AddTrustKeyPersonCommandHandler(IApplicationRepository applicationRepository, IMapper mapper)
+		public CreateTrustKeyPersonCommandHandler(IApplicationRepository applicationRepository, IMapper mapper)
 		{
 			_applicationRepository = applicationRepository;
 			_mapper = mapper;
 		}
 
-		public async Task<CommandResult> Handle(AddTrustKeyPersonCommand command, CancellationToken cancellationToken)
+		public async Task<CommandResult> Handle(CreateTrustKeyPersonCommand command, CancellationToken cancellationToken)
 		{
 			// cancellation token will be passed down to the database requests when the repository pattern is brought in
 			// shouldn't be anything that is long running just found it a good habit with async

--- a/Dfe.Academies.Academisation.Service/Commands/Application/DeleteSchoolCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/Application/DeleteSchoolCommandHandler.cs
@@ -1,0 +1,59 @@
+﻿using Dfe.Academies.Academisation.Core;
+using Dfe.Academies.Academisation.Data.ApplicationAggregate;
+using Dfe.Academies.Academisation.Domain.ApplicationAggregate;
+using Dfe.Academies.Academisation.Domain.ApplicationAggregate.Trusts;
+using Dfe.Academies.Academisation.Domain.Core.ApplicationAggregate;
+using Dfe.Academies.Academisation.IData.ApplicationAggregate;
+using Dfe.Academies.Academisation.IDomain.ApplicationAggregate;
+using Dfe.Academies.Academisation.IService.Commands.Application;
+using Dfe.Academies.Academisation.IService.ServiceModels.Application;
+using MediatR;
+
+namespace Dfe.Academies.Academisation.Service.Commands.Application
+{
+	public class DeleteSchoolCommandHandler : IRequestHandler<DeleteSchoolCommand, CommandResult>
+	{
+		private readonly IApplicationRepository _applicationRepository;
+
+		public DeleteSchoolCommandHandler(IApplicationRepository applicationRepository)
+		{
+			_applicationRepository = applicationRepository;
+		}
+
+		public async Task<CommandResult> Handle(DeleteSchoolCommand command, CancellationToken cancellationToken)
+		{
+			// cancellation token will be passed down to the database requests when the repository pattern is brought in
+			// shouldn't be anything that is long running just found it a good habit with async
+
+			var existingApplication = await _applicationRepository.GetByIdAsync(command.ApplicationId);
+
+			if (existingApplication is null)
+			{
+				return new NotFoundCommandResult();
+			}
+
+			var schoolToDelete = existingApplication.Schools.SingleOrDefault(x => x.Details.Urn == command.Urn);
+
+			var result = existingApplication.DeleteSchool(command.Urn);
+			
+			if (result is CommandValidationErrorResult)
+			{
+				return result;
+			}
+			if (result is not CommandSuccessResult)
+			{
+				throw new NotImplementedException();
+			}
+
+			_applicationRepository.Update(existingApplication);
+
+			//TODO: This can be removed when there is no longer a disconnect between domain and persistence entities
+			await _applicationRepository.DeleteChildObjectById<ApplicationSchoolState>(schoolToDelete.Id);
+
+			return await _applicationRepository.UnitOfWork.SaveEntitiesAsync(new CancellationToken())
+				? new CommandSuccessResult()
+				: new BadRequestCommandResult();
+		}
+
+	}
+}

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
@@ -119,7 +119,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 		}
 
 		[HttpPost("{applicationId}/form-trust/key-person", Name = "AddKeyPerson")]
-		public async Task<ActionResult> AddKeyPerson(int applicationId, [FromBody] AddTrustKeyPersonCommand command, CancellationToken cancellationToken)
+		public async Task<ActionResult> AddKeyPerson(int applicationId, [FromBody] CreateTrustKeyPersonCommand command, CancellationToken cancellationToken)
 		{
 			var result = await _mediator.Send(command with { ApplicationId = applicationId }, cancellationToken).ConfigureAwait(false);
 

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ApplicationController.cs
@@ -160,6 +160,20 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 			};
 		}
 
+		[HttpDelete("{applicationId}/form-trust/school/{urn}", Name = "DeleteSchool")]
+		public async Task<ActionResult> DeleteSchool(int applicationId, int urn, CancellationToken cancellationToken)
+		{
+			var result = await _mediator.Send(new DeleteSchoolCommand(applicationId, urn), cancellationToken).ConfigureAwait(false);
+
+			return result switch
+			{
+				CommandSuccessResult => Ok(),
+				NotFoundCommandResult => NotFound(),
+				CommandValidationErrorResult validationErrorResult => BadRequest(validationErrorResult.ValidationErrors),
+				_ => throw new NotImplementedException()
+			};
+		}
+
 		[HttpGet("{applicationId}/form-trust/key-person/", Name = "GetKeyPeople")]
 		public async Task<ActionResult<List<object>>> GetKeyPeople(int applicationId, CancellationToken cancellationToken)
 		{


### PR DESCRIPTION
Added an endpoint to delete schools from a FAM application.
May have to be revisited to deleted child objects when they are eventually added
Done on the key people branch I was doing some tidying changes at the same time 