### PR TITLE
set quoted_identifier on when executing migration script

### DIFF
--- a/script/sqlcmd-docker-entrypoint.sh
+++ b/script/sqlcmd-docker-entrypoint.sh
@@ -10,7 +10,7 @@ echo "CREATE DATABASE $MSSQL_INITIAL_DATABASE;" > ./setup.sql
 echo "GO" >> ./setup.sql
 
 echo "Creating initial database ..."
-until /opt/mssql-tools/bin/sqlcmd -S db -U sa -P "$MSSQL_SA_PASSWORD" -d master -i ./setup.sql
+until /opt/mssql-tools/bin/sqlcmd -S db -U sa -P "$MSSQL_SA_PASSWORD" -d master -I -i ./setup.sql
 do
   echo "not ready yet..."
   sleep 1

--- a/script/webapi-docker-entrypoint.sh
+++ b/script/webapi-docker-entrypoint.sh
@@ -15,7 +15,7 @@ do
 done
 
 echo "Running database migrations ..."
-until /opt/mssql-tools18/bin/sqlcmd -S "${mysqlconn[Server]}" -U "${mysqlconn[UserId]}" -P "${mysqlconn[Password]}" -d "${mysqlconn[Database]}" -C -i /app/SQL/DbMigrationScript.sql -o /app/SQL/DbMigrationScriptOutput.txt
+until /opt/mssql-tools18/bin/sqlcmd -S "${mysqlconn[Server]}" -U "${mysqlconn[UserId]}" -P "${mysqlconn[Password]}" -d "${mysqlconn[Database]}" -C -I -i /app/SQL/DbMigrationScript.sql -o /app/SQL/DbMigrationScriptOutput.txt
 do
   cat /app/SQL/DbMigrationScriptOutput.txt
   echo "Retrying database migrations ..."


### PR DESCRIPTION
fix for migration script not working due to quoted_identifier not set