### PR TITLE
Add test skip capability

### DIFF
--- a/CypressTests/cypress/e2e/FAM-AddTrustKeyPerson.cy.js
+++ b/CypressTests/cypress/e2e/FAM-AddTrustKeyPerson.cy.js
@@ -1,239 +1,237 @@
 /// <reference types="Cypress" />
 import { AuthorisedUserCanCreateNewFAMTrustKeyPersonBodyPayload } from '../support/payloads/FAM-TrustKeyPerson/AuthorisedUserCanCreateNewFAMTrustKeyPerson.spec'
-
 import { AuthorisedUserCanUpdateNewFAMTrustKeyPersonBodyPayload } from '../support/payloads/FAM-TrustKeyPerson/AuthorisedUserCanUpdateNewFAMTrustKeyPerson.spec'
 import { AuthorisedUserCannotCreateNewFAMTrustKeyPersonWITHINVALIDDOBBodyPayload } from '../support/payloads/FAM-TrustKeyPerson/AuthorisedUserCannotCreateNewFAMTrustKeyPersonWITHINVALIDDOB.spec'
 import { UnauthorisedUserCannotUpdateNewFAMTrustKeyPersonBodyPayload } from '../support/payloads/FAM-TrustKeyPerson/UnauthorisedUserCannotUpdateNewFAMTrustKeyPerson.spec'
+
 describe('Academisation API Testing - FAM - Add Trust Key Person', () => {
+  let apiKey = Cypress.env('apiKey');
+  let url = Cypress.env('url');
+  let applicationNumber = 10038;
+  let trustKeyPersonNumber = 0;
 
+  it('POST - Verify An UnAuthorised User Is Unable To Create New FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
+    cy.skipWhen(url.includes('dev'), this)
 
-    let apiKey = Cypress.env('apiKey');
-    let url = Cypress.env('url');
-    let applicationNumber = 10038;
-    let trustKeyPersonNumber = 0;
-
-    /********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-    it('POST - Verify An UnAuthorised User Is Unable To Create New FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', () => {
-      cy.request({
-              method: 'POST',
-              url: url + '/application/' + applicationNumber + '/form-trust/key-person',
-              failOnStatusCode: false,
-              headers: 
-              {
-                'x-api-key' : 'INVALIDAPIKEY'
-              },
-              body: 
-              AuthorisedUserCanCreateNewFAMTrustKeyPersonBodyPayload
-          }).then((response) => {
-
-          expect(response).to.have.property('status', 401)
-
-          })
-  })
-  */
-
-    it('POST - Verify An Authorised User Is Able To Create New FAM-Trust Key Person - Form-Trust Key-Person - 200 CREATED Expected', () => {
-          cy.request({
-                  method: 'POST',
-                  url: url + '/application/' + applicationNumber + '/form-trust/key-person',
-                  headers: 
-                  {
-                    'x-api-key' : apiKey
-                  },
-                  body: 
-                  AuthorisedUserCanCreateNewFAMTrustKeyPersonBodyPayload
-              }).then((response) => {
-
-              expect(response).to.have.property('status', 200)
-
-              })
-      })
-
-      it('POST - Verify An Authorised User Is Unable To Create New FAM-Trust Key Person - Form-Trust Key-Person WITH AN INVALID DOB - 400 BAD REQUEST Expected', () => {
-        cy.request({
-                method: 'POST',
-                url: url + '/application/' + applicationNumber + '/form-trust/key-person',
-                failOnStatusCode: false,
-                headers: 
-                {
-                  'x-api-key' : apiKey
-                },
-                body: 
-                AuthorisedUserCannotCreateNewFAMTrustKeyPersonWITHINVALIDDOBBodyPayload
-            }).then((response) => {
-
-            expect(response).to.have.property('status', 400)
-  
-            })
-    })
-
-    /********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-      it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key PERSONS - Form-Trust Key-PersonS - 401 UNAUTHORISED Expected', () => {
-        cy.request({
-                method: 'GET',
-                url: url + '/application/' + applicationNumber + '/form-trust/key-person',
-                failOnStatusCode: false,
-                headers: 
-                {
-                  'x-api-key' : 'INVALIDAPIKEY'
-                },
-            }).then((response) => {
-
-                expect(response).to.have.property('status', 401)
-    })
-  })
-*/
-      it('GET - Verify An Authorised User Is Able To GET FAM-Trust Key PERSONS - Form-Trust Key-PersonS - 200 OK Expected', () => {
-        cy.request({
-                method: 'GET',
-                url: url + '/application/' + applicationNumber + '/form-trust/key-person',
-                headers: 
-                {
-                  'x-api-key' : apiKey
-                },
-            }).then((response) => {
-
-                expect(response).to.have.property('status', 200)
-                expect(response.body[0]).to.have.property('id')
-                trustKeyPersonNumber = response.body[0].id;
-
-
-    })
-
-  })
-
-  /********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-  it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', () => {
     cy.request({
-            method: 'GET',
-            url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + 105,
-            failOnStatusCode: false,
-            headers: 
-            {
-              'x-api-key' : 'INVALIDAPIKEY'
-            },
-        }).then((response) => {
-
-            expect(response).to.have.property('status', 401)
-
-})
-
-})
-*/
-
-  it('GET - Verify An Authorised User Is Able To GET FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
-    cy.request({
-            method: 'GET',
-            url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + trustKeyPersonNumber,
-            headers: 
-            {
-              'x-api-key' : apiKey
-            },
-        }).then((response) => {
-
-            expect(response).to.have.property('status', 200)
-            expect(response.body).to.have.property('id')
-
-
-})
-
-})
-
-/********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-it('PUT - Verify An UNAuthorised User Is UNAble To UPDATE a FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', () => {
-
-
-cy.log(JSON.stringify("Id = " + Cypress.env('responseIDForRequest')))
-cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + 19,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : 'INVALIDAPIKEY'
-        },
-        body:
-        UnauthorisedUserCannotUpdateNewFAMTrustKeyPersonBodyPayload
+      method: 'POST',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person',
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': 'INVALIDAPIKEY'
+      },
+      body:
+        AuthorisedUserCanCreateNewFAMTrustKeyPersonBodyPayload
     }).then((response) => {
-
-    expect(response).to.have.property('status', 401)
-  })
-
-})
-*/
-
-  it('PUT - Verify An Authorised User Is Able To UPDATE a FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
-    cy.request({
-            method: 'PUT',
-            url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + trustKeyPersonNumber,
-            headers: 
-            {
-              'x-api-key' : apiKey
-            },
-            body:
-            AuthorisedUserCanUpdateNewFAMTrustKeyPersonBodyPayload
-        }).then((response) => {
-   
-        expect(response).to.have.property('status', 200)
-      })
-})
-
-//  NEED TO COMMENT OUT THE UNAUTH DELETE AS THIS IS NOW DELETING WHEN IT SHOULDN'T BE
-/*
-it('DELETE - Verify An UNAuthorised User Is UNable To DELETE FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', () => {
-  cy.request({
-          method: 'DELETE',
-          url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + Cypress.env('responseIDForRequest'),
-          failOnStatusCode: false,
-          headers: 
-          {
-            'x-api-key' : 'INVALID APIKEY'
-          },
-      }).then((response) => {
 
       expect(response).to.have.property('status', 401)
 
-      })
     })
-  */
-
-    // BEST TO TAKE THIS ONE OUT THE PIPELINE SO WE DON'T RUN OUT OF PEOPLE TO DELETE
-/*
-  it('DELETE - Verify An Authorised User Is Able To DELETE FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
-    cy.request({
-            method: 'DELETE',
-            url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + Cypress.env('responseIDForRequest'),
-            headers: 
-            {
-              'x-api-key' : apiKey
-            },
-        }).then((response) => {
-   
-        expect(response).to.have.property('status', 200)
-
-        })
   })
-  */
 
-  // WE DON'T CARE ABOUT THIS RIGHT NOW
-/*
-  it('DELETE - Verify An Authorised User Is UNable To DELETE FAM-Trust Key Person THAT DOES NOT EXIST - Form-Trust Key-Person THAT DOES NOT EXIST - 500 SERVER ERROR Expected - (May change to 400 later)', () => {
+  it('POST - Verify An Authorised User Is Able To Create New FAM-Trust Key Person - Form-Trust Key-Person - 200 CREATED Expected', () => {
+    cy.request({
+      method: 'POST',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person',
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+        AuthorisedUserCanCreateNewFAMTrustKeyPersonBodyPayload
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 200)
+
+    })
+  })
+
+  it('POST - Verify An Authorised User Is Unable To Create New FAM-Trust Key Person - Form-Trust Key-Person WITH AN INVALID DOB - 400 BAD REQUEST Expected', () => {
+    cy.request({
+      method: 'POST',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person',
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+        AuthorisedUserCannotCreateNewFAMTrustKeyPersonWITHINVALIDDOBBodyPayload
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 400)
+
+    })
+  })
+
+  it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key PERSONS - Form-Trust Key-PersonS - 401 UNAUTHORISED Expected', function () {
+    cy.skipWhen(url.includes('dev'), this)
+
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person',
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': 'INVALIDAPIKEY'
+      },
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 401)
+    })
+  })
+
+  it('GET - Verify An Authorised User Is Able To GET FAM-Trust Key PERSONS - Form-Trust Key-PersonS - 200 OK Expected', () => {
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person',
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 200)
+      expect(response.body[0]).to.have.property('id')
+      trustKeyPersonNumber = response.body[0].id;
+
+
+    })
+
+  })
+
+  it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
+    cy.skipWhen(url.includes('dev'), this)
+
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + 105,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': 'INVALIDAPIKEY'
+      },
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 401)
+
+    })
+
+  })
+
+  it('GET - Verify An Authorised User Is Able To GET FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + trustKeyPersonNumber,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 200)
+      expect(response.body).to.have.property('id')
+
+
+    })
+
+  })
+
+  it('PUT - Verify An UNAuthorised User Is UNAble To UPDATE a FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
+
+    cy.skipWhen(url.includes('dev'), this)
+
+    cy.log(JSON.stringify("Id = " + Cypress.env('responseIDForRequest')))
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + 19,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': 'INVALIDAPIKEY'
+      },
+      body:
+        UnauthorisedUserCannotUpdateNewFAMTrustKeyPersonBodyPayload
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 401)
+    })
+
+  })
+
+  it('PUT - Verify An Authorised User Is Able To UPDATE a FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + trustKeyPersonNumber,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+        AuthorisedUserCanUpdateNewFAMTrustKeyPersonBodyPayload
+    }).then((response) => {
+
+      expect(response).to.have.property('status', 200)
+    })
+  })
+
+  //  NEED TO COMMENT OUT THE UNAUTH DELETE AS THIS IS NOW DELETING WHEN IT SHOULDN'T BE
+  /*
+  it('DELETE - Verify An UNAuthorised User Is UNable To DELETE FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', () => {
     cy.request({
             method: 'DELETE',
             url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + Cypress.env('responseIDForRequest'),
             failOnStatusCode: false,
             headers: 
             {
-              'x-api-key' : apiKey
+              'x-api-key' : 'INVALID APIKEY'
             },
         }).then((response) => {
-
-        expect(response).to.have.property('status', 400)
+  
+        expect(response).to.have.property('status', 401)
   
         })
-  })
-  */
+      })
+    */
 
+  // BEST TO TAKE THIS ONE OUT THE PIPELINE SO WE DON'T RUN OUT OF PEOPLE TO DELETE
+  /*
+    it('DELETE - Verify An Authorised User Is Able To DELETE FAM-Trust Key Person - Form-Trust Key-Person - 200 OK Expected', () => {
+      cy.request({
+              method: 'DELETE',
+              url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + Cypress.env('responseIDForRequest'),
+              headers: 
+              {
+                'x-api-key' : apiKey
+              },
+          }).then((response) => {
+     
+          expect(response).to.have.property('status', 200)
   
+          })
+    })
+    */
+
+  // WE DON'T CARE ABOUT THIS RIGHT NOW
+  /*
+    it('DELETE - Verify An Authorised User Is UNable To DELETE FAM-Trust Key Person THAT DOES NOT EXIST - Form-Trust Key-Person THAT DOES NOT EXIST - 500 SERVER ERROR Expected - (May change to 400 later)', () => {
+      cy.request({
+              method: 'DELETE',
+              url: url + '/application/' + applicationNumber + '/form-trust/key-person' + '/' + Cypress.env('responseIDForRequest'),
+              failOnStatusCode: false,
+              headers: 
+              {
+                'x-api-key' : apiKey
+              },
+          }).then((response) => {
+  
+          expect(response).to.have.property('status', 400)
+    
+          })
+    })
+    */
+
+
 
 })

--- a/CypressTests/cypress/e2e/FAM-AddTrustKeyPerson.cy.js
+++ b/CypressTests/cypress/e2e/FAM-AddTrustKeyPerson.cy.js
@@ -11,7 +11,7 @@ describe('Academisation API Testing - FAM - Add Trust Key Person', () => {
   let trustKeyPersonNumber = 0;
 
   it('POST - Verify An UnAuthorised User Is Unable To Create New FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.request({
       method: 'POST',
@@ -66,7 +66,7 @@ describe('Academisation API Testing - FAM - Add Trust Key Person', () => {
   })
 
   it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key PERSONS - Form-Trust Key-PersonS - 401 UNAUTHORISED Expected', function () {
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.request({
       method: 'GET',
@@ -102,7 +102,7 @@ describe('Academisation API Testing - FAM - Add Trust Key Person', () => {
   })
 
   it('GET - Verify An UNAuthorised User Is UNAble To GET FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.request({
       method: 'GET',
@@ -140,7 +140,7 @@ describe('Academisation API Testing - FAM - Add Trust Key Person', () => {
 
   it('PUT - Verify An UNAuthorised User Is UNAble To UPDATE a FAM-Trust Key Person - Form-Trust Key-Person - 401 UNAUTHORISED Expected', function () {
 
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.log(JSON.stringify("Id = " + Cypress.env('responseIDForRequest')))
     cy.request({

--- a/CypressTests/cypress/e2e/Get-UpdateApplication.cy.js
+++ b/CypressTests/cypress/e2e/Get-UpdateApplication.cy.js
@@ -1,269 +1,271 @@
 /// <reference types="Cypress" />
-import {UnauthorisedUserCannotUpdatePayload} from '../support/payloads/UnauthorisedUserCannotUpdateBody.spec'
-import {AuthorisedUserCanUpdatePayload} from '../support/payloads/AuthorisedUserCanUpdate.spec'
-import {AuthorisedUserCannotUpdateTheirContributorsEmailToAnotherEmailBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeTheirContributorsEmailToAnotherEmail.spec'
-import {AuthorisedUserCannotUpdateTheirContributorsEmailToInvalidEmailBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeTheirContributorsEmailToInvalidEmail.spec'
-import {AuthorisedUserCannotUpdateWorksPlannedDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeWorksPlannedDateToInvalidDate.spec'
-import {AuthorisedUserCannotUpdateSacreExemptionEndDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeSacreExemptionEndDateToInvalidDate.spec'
-import {AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBody.spec'
-import {AuthorisedUserCannotUpdatePreviousFinancialYearEndDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotChangePreviousFinancialYearEndDateToInvalidDate.spec'
-import {AuthorisedUserCannotUpdateCurrentFinancialYearEndDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeCurrentFinancialYearEndDateToInvalidDate.spec'
-import {AuthorisedUserCannotUpdateNextFinancialYearEndDateToInvalidDateBodyPayload} from '../support/payloads/AuthorisedUserCannotChangeNextFinancialYearEndDateToInvalidDate.spec'
+import { UnauthorisedUserCannotUpdatePayload } from '../support/payloads/UnauthorisedUserCannotUpdateBody.spec'
+import { AuthorisedUserCanUpdatePayload } from '../support/payloads/AuthorisedUserCanUpdate.spec'
+import { AuthorisedUserCannotUpdateTheirContributorsEmailToAnotherEmailBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeTheirContributorsEmailToAnotherEmail.spec'
+import { AuthorisedUserCannotUpdateTheirContributorsEmailToInvalidEmailBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeTheirContributorsEmailToInvalidEmail.spec'
+import { AuthorisedUserCannotUpdateWorksPlannedDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeWorksPlannedDateToInvalidDate.spec'
+import { AuthorisedUserCannotUpdateSacreExemptionEndDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeSacreExemptionEndDateToInvalidDate.spec'
+import { AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBody.spec'
+import { AuthorisedUserCannotUpdatePreviousFinancialYearEndDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotChangePreviousFinancialYearEndDateToInvalidDate.spec'
+import { AuthorisedUserCannotUpdateCurrentFinancialYearEndDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeCurrentFinancialYearEndDateToInvalidDate.spec'
+import { AuthorisedUserCannotUpdateNextFinancialYearEndDateToInvalidDateBodyPayload } from '../support/payloads/AuthorisedUserCannotChangeNextFinancialYearEndDateToInvalidDate.spec'
 
 
 describe('Academisation API Testing', () => {
 
-    let apiKey = Cypress.env('apiKey');
-    let url = Cypress.env('url');
-    let applicationNumber = 10002
-    let emailRegex = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/
-    let getDateTimestampFormatRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})Z?$/
-   
-
-    it('GET - Verify An Authorised User Can Retrieve A Respective Application - 200 OK EXPECTED', () => {
-          cy.request({
-                  method: 'GET',
-                  url: url + '/application/' + applicationNumber,
-                  headers: 
-                  {
-                    'x-api-key' : apiKey
-                  }
-              }).then((response) => {
-              cy.log(JSON.stringify(response))
-              expect(response).to.have.property('status', 200)
-              expect(response.body).to.have.property('contributors')
-              expect(response.body.contributors[0]).to.have.property('firstName')
-              expect(response.body.contributors[0]).to.have.property('lastName')
-              expect(response.body.contributors[0]).to.have.property('emailAddress').to.match(emailRegex)
-              expect(response.body.contributors[0]).to.have.property('role')
-
-              
-              expect(response.body).to.have.property('schools')
-
-              // PREVIOUS FINANCIAL YEAR PROPERTIES
-              expect(response.body.schools[0].previousFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
-              expect(response.body.schools[0].previousFinancialYear).to.have.property('revenue')
-              expect(response.body.schools[0].previousFinancialYear).to.have.property('revenueStatus')
-
-              expect(response.body.schools[0].previousFinancialYear).to.have.property('capitalCarryForward')
-              expect(response.body.schools[0].previousFinancialYear).to.have.property('capitalCarryForwardStatus')
+  let apiKey = Cypress.env('apiKey');
+  let url = Cypress.env('url');
+  let applicationNumber = 10002
+  let emailRegex = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/
+  let getDateTimestampFormatRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})Z?$/
 
 
-              // CURRENT FINANCIAL YEAR PROPERTIES
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('revenue')
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('revenueStatus')
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('revenueStatusExplained')
+  it('GET - Verify An Authorised User Can Retrieve A Respective Application - 200 OK EXPECTED', () => {
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber,
+      headers:
+      {
+        'x-api-key': apiKey
+      }
+    }).then((response) => {
+      cy.log(JSON.stringify(response))
+      expect(response).to.have.property('status', 200)
+      expect(response.body).to.have.property('contributors')
+      expect(response.body.contributors[0]).to.have.property('firstName')
+      expect(response.body.contributors[0]).to.have.property('lastName')
+      expect(response.body.contributors[0]).to.have.property('emailAddress').to.match(emailRegex)
+      expect(response.body.contributors[0]).to.have.property('role')
 
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForward')
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForwardStatus')
-              expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForwardExplained')
+
+      expect(response.body).to.have.property('schools')
+
+      // PREVIOUS FINANCIAL YEAR PROPERTIES
+      expect(response.body.schools[0].previousFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
+      expect(response.body.schools[0].previousFinancialYear).to.have.property('revenue')
+      expect(response.body.schools[0].previousFinancialYear).to.have.property('revenueStatus')
+
+      expect(response.body.schools[0].previousFinancialYear).to.have.property('capitalCarryForward')
+      expect(response.body.schools[0].previousFinancialYear).to.have.property('capitalCarryForwardStatus')
 
 
-              // NEXT FINANCIAL YEAR PROPERTIES
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('revenue')
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('revenueStatus')
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('revenueStatusExplained')
+      // CURRENT FINANCIAL YEAR PROPERTIES
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('revenue')
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('revenueStatus')
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('revenueStatusExplained')
 
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForward')
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForwardStatus')
-              expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForwardExplained')
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForward')
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForwardStatus')
+      expect(response.body.schools[0].currentFinancialYear).to.have.property('capitalCarryForwardExplained')
 
-              })
-      })
-/********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-      it('GET - Verify An UNAUTHORISED USER CANNOT Retreive An Application - 401 UNAUTHORISED EXPECTED', () => {
-        cy.request({
-              method: 'GET',
-              url: url + '/application/' + applicationNumber,
-              failOnStatusCode: false
-              }).then((response) => {
-                expect(response).to.have.property('status', 401)
-              })
-      })
-      */
 
-      it('PUT - Verify An Authorised User Can Update An Application Correctly - 200 OK EXPECTED', () => {
-        cy.request({
-              method: 'PUT',
-              url: url + '/application/' + applicationNumber,
-              headers: 
-              {
-                'x-api-key' : apiKey
-              },
-              body:
-              AuthorisedUserCanUpdatePayload
-            }).then((response) => {
-                cy.log(JSON.stringify(response))
-                expect(response).to.have.property('status', 200)
+      // NEXT FINANCIAL YEAR PROPERTIES
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('financialYearEndDate').to.match(getDateTimestampFormatRegex)
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('revenue')
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('revenueStatus')
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('revenueStatusExplained')
+
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForward')
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForwardStatus')
+      expect(response.body.schools[0].nextFinancialYear).to.have.property('capitalCarryForwardExplained')
+
+    })
+  })
+
+  it('GET - Verify An UNAUTHORISED USER CANNOT Retreive An Application - 401 UNAUTHORISED EXPECTED', function () {
+    cy.skipWhen(url.includes('dev'), this)
+
+    cy.request({
+      method: 'GET',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false
+    }).then((response) => {
+      expect(response).to.have.property('status', 401)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Can Update An Application Correctly - 200 OK EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+        AuthorisedUserCanUpdatePayload
+    }).then((response) => {
+      cy.log(JSON.stringify(response))
+      expect(response).to.have.property('status', 200)
     })
   })
 
   it('PUT - Verify An Authorised User Is Unable To Change Their Contributor\'s Email to ANOTHER EMAIL ADDRESS - 400 BAD REQUEST EXPECTED', () => {
     cy.request({
-          method: 'PUT',
-          url: url + '/application/' + applicationNumber,
-          failOnStatusCode: false,
-          headers: 
-          {
-            'x-api-key' :  apiKey
-          },
-          body: 
-          
-            AuthorisedUserCannotUpdateTheirContributorsEmailToAnotherEmailBodyPayload
-        
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
 
-          }).then((response) => {
-          expect(response).to.have.property('status', 400)
+        AuthorisedUserCannotUpdateTheirContributorsEmailToAnotherEmailBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
     })
-})
+  })
 
   it('PUT - Verify An Authorised User Is Unable To Change Their Contributor\'s Email to AN INVALID EMAIL ADDRESS - 400 BAD REQUEST EXPECTED', () => {
     cy.request({
-          method: 'PUT',
-          url: url + '/application/' + applicationNumber,
-          failOnStatusCode: false,
-          headers: 
-          {
-            'x-api-key' : apiKey
-          },
-          body: 
-          
-            AuthorisedUserCannotUpdateTheirContributorsEmailToInvalidEmailBodyPayload
-        
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
 
-          }).then((response) => {
-          expect(response).to.have.property('status', 400)
-    })
-})
+        AuthorisedUserCannotUpdateTheirContributorsEmailToInvalidEmailBodyPayload
 
-it('PUT - Verify An Authorised User Is Unable To Change The worksPlannedDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body: 
-        
-         
-            AuthorisedUserCannotUpdateWorksPlannedDateToInvalidDateBodyPayload
-        
 
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-
-it('PUT - Verify An Authorised User Is Unable To Change The sacreExemptionDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body: 
-        
-            AuthorisedUserCannotUpdateSacreExemptionEndDateToInvalidDateBodyPayload
-      
-
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-
-it('PUT - Verify An Authorised User Is Unable To Change The previousFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body: 
-        
-            AuthorisedUserCannotUpdatePreviousFinancialYearEndDateToInvalidDateBodyPayload
-        
-
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-
-it('PUT - Verify An Authorised User Is Unable To Change The currentFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body: 
-        
-            AuthorisedUserCannotUpdateCurrentFinancialYearEndDateToInvalidDateBodyPayload
-        
-
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-
-it('PUT - Verify An Authorised User Is Unable To Change The nextFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body: 
-        
-            AuthorisedUserCannotUpdateNextFinancialYearEndDateToInvalidDateBodyPayload
-         
-    
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-
-it('PUT - Verify An Authorised User Is Unable To Change The schoolConversionTargetDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
-  cy.request({
-        method: 'PUT',
-        url: url + '/application/' + applicationNumber,
-        failOnStatusCode: false,
-        headers: 
-        {
-          'x-api-key' : apiKey
-        },
-        body:
-            AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBodyPayload
-        
-
-        }).then((response) => {
-        expect(response).to.have.property('status', 400)
-    })
-})
-      /********************* COMMENTING THIS OUT FOR THE PIPELINES IN DEV!!!!!!!  ******************
-      it('PUT - Verify An UNAUTHORISED USER CANNOT Update An Application - 401 UNAUTHORISED EXPECTED', () => {
-        cy.request({
-            method: 'PUT', 
-            url: url + '/application/' + applicationNumber,
-            failOnStatusCode: false,
-            body:
-            UnauthorisedUserCannotUpdatePayload
-
-              }).then((response) => {
-              expect(response).to.have.property('status', 401)
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
     })
   })
-*/
+
+  it('PUT - Verify An Authorised User Is Unable To Change The worksPlannedDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+
+
+        AuthorisedUserCannotUpdateWorksPlannedDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Is Unable To Change The sacreExemptionDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+
+        AuthorisedUserCannotUpdateSacreExemptionEndDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Is Unable To Change The previousFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+
+        AuthorisedUserCannotUpdatePreviousFinancialYearEndDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Is Unable To Change The currentFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+
+        AuthorisedUserCannotUpdateCurrentFinancialYearEndDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Is Unable To Change The nextFinancialYearEndDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+
+        AuthorisedUserCannotUpdateNextFinancialYearEndDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An Authorised User Is Unable To Change The schoolConversionTargetDate To An Invalid Date - 400 BAD REQUEST EXPECTED', () => {
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      headers:
+      {
+        'x-api-key': apiKey
+      },
+      body:
+        AuthorisedUserCannotUpdateSchoolConversionTargetDateToInvalidDateBodyPayload
+
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 400)
+    })
+  })
+
+  it('PUT - Verify An UNAUTHORISED USER CANNOT Update An Application - 401 UNAUTHORISED EXPECTED', function () {
+    cy.skipWhen(url.includes('dev'), this)
+
+    cy.request({
+      method: 'PUT',
+      url: url + '/application/' + applicationNumber,
+      failOnStatusCode: false,
+      body:
+        UnauthorisedUserCannotUpdatePayload
+
+    }).then((response) => {
+      expect(response).to.have.property('status', 401)
+    })
+  })
 
 })

--- a/CypressTests/cypress/e2e/Get-UpdateApplication.cy.js
+++ b/CypressTests/cypress/e2e/Get-UpdateApplication.cy.js
@@ -74,7 +74,7 @@ describe('Academisation API Testing', () => {
   })
 
   it('GET - Verify An UNAUTHORISED USER CANNOT Retreive An Application - 401 UNAUTHORISED EXPECTED', function () {
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.request({
       method: 'GET',
@@ -254,7 +254,7 @@ describe('Academisation API Testing', () => {
   })
 
   it('PUT - Verify An UNAUTHORISED USER CANNOT Update An Application - 401 UNAUTHORISED EXPECTED', function () {
-    cy.skipWhen(url.includes('dev'), this)
+    cy.skipWhen(url.includes('d01'), this)
 
     cy.request({
       method: 'PUT',

--- a/CypressTests/cypress/support/commands.js
+++ b/CypressTests/cypress/support/commands.js
@@ -23,3 +23,15 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+/**
+ * Adds a skip capability based on an expression for tests.
+ * NOTE: You will need to use es5 syntax to be able to access context e.g.
+ *
+ * it('does a thing', function () { //do something })
+ */
+Cypress.Commands.add('skipWhen', (expr, context) => {
+    if(expr) {
+        context.skip.bind(context)();
+    }
+})


### PR DESCRIPTION
Adds a Cypress command to enable test skips when conditions are met.

The command is in support/commands.js and will take any boolean expression as an arg.

Note: to be able to use it and use the Mocha test context, any test will need to use es5 syntax for functions, namely:

    it('does a thing', function () { //do something })

rather than

    it('does a thing', () => { //do something })

In the skipped tests, I'm currently evaluating against the url containing 'dev' to skip on dev environment, but you may want to change the expression if this won't work.

Also fixes formatting in test classes.