### PR TITLE
Always use an API Key to authenticate

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/Program.cs
+++ b/Dfe.Academies.Academisation.WebApi/Program.cs
@@ -210,10 +210,7 @@ app.UseSwaggerUI();
 app.UseHttpsRedirection();
 app.UseAuthorization();
 
-if (!app.Environment.IsDevelopment())
-{
-	app.UseMiddleware<ApiKeyAuthenticationMiddleware>();
-}
+app.UseMiddleware<ApiKeyAuthenticationMiddleware>();
 app.UseMiddleware<AddCorrelationIdMiddleware>();
 app.UseMiddleware<RequestLoggingMiddleware>();
 


### PR DESCRIPTION
Bypassing the API Key check if the environment is Development could be problematic from a security posture point of view.

This PR is a remediation to ensure that all requests must offer a valid API Key