### PR TITLE
Feature/129594 save local authority for involutary conversions

### DIFF
--- a/Dfe.Academies.Academisation.Domain.Core/ProjectAggregate/SponsoredProject.cs
+++ b/Dfe.Academies.Academisation.Domain.Core/ProjectAggregate/SponsoredProject.cs
@@ -2,5 +2,5 @@
 {
 	public record SponsoredProject(SponsoredProjectSchool? School, SponsoredProjectTrust? Trust);
 	public record SponsoredProjectTrust(string Name, string ReferenceNumber);
-	public record SponsoredProjectSchool(string Name, int Urn, DateTime? OpeningDate, bool? PartOfPfiScheme);
+	public record SponsoredProjectSchool(string Name, int Urn, DateTime? OpeningDate, bool? PartOfPfiScheme, string? LocalAuthorityName, string? Region);
 }

--- a/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
+++ b/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
@@ -116,6 +116,8 @@ public class Project : IProject
 
 	public static CreateResult CreateSponsoredProject(SponsoredProject project)
 	{
+		ArgumentNullException.ThrowIfNull(project);
+
 		if (project.Trust == null)
 		{
 			return new CreateValidationErrorResult(new List<ValidationError>
@@ -141,7 +143,9 @@ public class Project : IProject
 			NameOfTrust = project.Trust?.Name,
 			AcademyTypeAndRoute = "Sponsored",
 			ConversionSupportGrantAmount = 25000,
-			PartOfPfiScheme = ToYesNoString(project.School?.PartOfPfiScheme) ?? "No"
+			PartOfPfiScheme = ToYesNoString(project.School?.PartOfPfiScheme) ?? "No",
+			LocalAuthority = project.School?.LocalAuthorityName,
+			Region = project.School?.Region
 		};
 
 		return new CreateSuccessResult<IProject>(new Project(projectDetails));

--- a/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/SponsoredProjectServiceModel.cs
+++ b/Dfe.Academies.Academisation.IService/ServiceModels/Legacy/ProjectAggregate/SponsoredProjectServiceModel.cs
@@ -18,5 +18,7 @@
 		public int Urn { get; init; }
 		public DateTime OpeningDate { get; init; }
 		public bool PartOfPfiScheme { get; init; }
+		public string? LocalAuthorityName { get; init; }
+		public string? Region{ get; init; }
 	}
 }

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ApplicationAggregate/ApplicationSubmitTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ApplicationAggregate/ApplicationSubmitTests.cs
@@ -137,7 +137,7 @@ public class ApplicationSubmitTests
 
 		Assert.Equal(ApplicationStatus.Submitted, getPayload.ApplicationStatus);
 
-		var projectController = new LegacyProjectController(new LegacyProjectGetQuery(new ProjectGetDataQuery(_context)), Mock.Of<ILegacyProjectListGetQuery>(),
+		var projectController = new ProjectController(new LegacyProjectGetQuery(new ProjectGetDataQuery(_context)), Mock.Of<ILegacyProjectListGetQuery>(),
 			Mock.Of<IProjectGetStatusesQuery>(), Mock.Of<ILegacyProjectUpdateCommand>(), Mock.Of<ILegacyProjectAddNoteCommand>(), Mock.Of<ILegacyProjectDeleteNoteCommand>(),
 			Mock.Of<ICreateSponsoredProjectCommand>());
 		var projectResult = await projectController.Get(1);
@@ -192,7 +192,7 @@ public class ApplicationSubmitTests
 
 		Assert.Equal(ApplicationStatus.Submitted, getPayload.ApplicationStatus);
 
-		var projectController = new LegacyProjectController(new LegacyProjectGetQuery(new ProjectGetDataQuery(_context)), new LegacyProjectListGetQuery(new ProjectListGetDataQuery(_context)),
+		var projectController = new ProjectController(new LegacyProjectGetQuery(new ProjectGetDataQuery(_context)), new LegacyProjectListGetQuery(new ProjectListGetDataQuery(_context)),
 			Mock.Of<IProjectGetStatusesQuery>(), Mock.Of<ILegacyProjectUpdateCommand>(), Mock.Of<ILegacyProjectAddNoteCommand>(), Mock.Of<ILegacyProjectDeleteNoteCommand>(),
 			Mock.Of<ICreateSponsoredProjectCommand>());
 		var projectResults = await projectController.GetProjects(new GetAcademyConversionSearchModel(1, 3, null, null, null, null, new[] { $"A2B_{createdPayload.ApplicationReference!}" }));

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectAddNoteTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectAddNoteTests.cs
@@ -31,9 +31,9 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate
 			_createSponsoredProjectCommand = Mock.Of<ICreateSponsoredProjectCommand>();
 		}
 
-		private LegacyProjectController System_under_test()
+		private ProjectController System_under_test()
 		{
-			return new LegacyProjectController(
+			return new ProjectController(
 				_projectGetQuery,
 				_projectListGetQuery,
 				_getStatusesQuery,
@@ -50,7 +50,7 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate
 				.Setup(x => x.Execute(It.IsAny<LegacyProjectAddNoteModel>()))
 				.Returns(Task.FromResult(new CommandSuccessResult() as CommandResult));
 
-			LegacyProjectController controller = System_under_test();
+			ProjectController controller = System_under_test();
 
 			ActionResult result =
 				await controller.AddNote(1234, new AddNoteRequest("Subject", "Note", "Author", DateTime.Today));
@@ -65,7 +65,7 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate
 				.Setup(x => x.Execute(It.IsAny<LegacyProjectAddNoteModel>()))
 				.Returns(Task.FromResult(new NotFoundCommandResult() as CommandResult));
 
-			LegacyProjectController controller = System_under_test();
+			ProjectController controller = System_under_test();
 
 			ActionResult result =
 				await controller.AddNote(1234, new AddNoteRequest("Subject", "Note", "Author", DateTime.UtcNow));

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectGetStatusesTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectGetStatusesTests.cs
@@ -13,7 +13,7 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate;
 
 public class LegacyProjectGetStatusesTests
 {
-	private readonly LegacyProjectController _legacyProjectController;
+	private readonly ProjectController _projectController;
 	private readonly AcademisationContext _context;
 
 	public LegacyProjectGetStatusesTests()
@@ -23,7 +23,7 @@ public class LegacyProjectGetStatusesTests
 		IProjectStatusesDataQuery dataQuery = new ProjectStatusesDataQuery(_context);
 		IProjectGetStatusesQuery query = new ProjectGetStatusesQuery(dataQuery);
 
-		_legacyProjectController = new LegacyProjectController(Mock.Of<ILegacyProjectGetQuery>(), Mock.Of<ILegacyProjectListGetQuery>(),
+		_projectController = new ProjectController(Mock.Of<ILegacyProjectGetQuery>(), Mock.Of<ILegacyProjectListGetQuery>(),
 			query, Mock.Of<ILegacyProjectUpdateCommand>(), Mock.Of<ILegacyProjectAddNoteCommand>(), Mock.Of<ILegacyProjectDeleteNoteCommand>(), Mock.Of<ICreateSponsoredProjectCommand>());
 	}
 
@@ -35,7 +35,7 @@ public class LegacyProjectGetStatusesTests
 		await _context.SaveChangesAsync();
 
 		// act
-		var result = await _legacyProjectController.GetFilterParameters();
+		var result = await _projectController.GetFilterParameters();
 
 		// assert
 		var response = DfeAssert.OkObjectResult(result);

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectGetTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectGetTests.cs
@@ -16,7 +16,7 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate;
 
 public class ProjectGetTests
 {
-	private readonly LegacyProjectController _legacyProjectController;
+	private readonly ProjectController _projectController;
 	private readonly AcademisationContext _context;
 	private readonly Fixture _fixture = new();
 
@@ -27,7 +27,7 @@ public class ProjectGetTests
 		IProjectGetDataQuery projectGetDataQuery = new ProjectGetDataQuery(_context);
 		ILegacyProjectGetQuery legacyProjectGetQuery = new LegacyProjectGetQuery(projectGetDataQuery);
 
-		_legacyProjectController = new LegacyProjectController(legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
+		_projectController = new ProjectController(legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
 			Mock.Of<IProjectGetStatusesQuery>(), Mock.Of<ILegacyProjectUpdateCommand>(), Mock.Of<ILegacyProjectAddNoteCommand>(),
 			Mock.Of<ILegacyProjectDeleteNoteCommand>(), Mock.Of<ICreateSponsoredProjectCommand>());
 	}
@@ -40,7 +40,7 @@ public class ProjectGetTests
 		await _context.SaveChangesAsync();
 
 		// act
-		ActionResult<LegacyProjectServiceModel> result = await _legacyProjectController.Get(existingProject.Id);
+		ActionResult<LegacyProjectServiceModel> result = await _projectController.Get(existingProject.Id);
 
 		// assert
 		result.Result.Should().BeOfType<OkObjectResult>();

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectListGetTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectListGetTests.cs
@@ -14,7 +14,7 @@ namespace Dfe.Academies.Academisation.SubcutaneousTest.ProjectAggregate;
 
 public class LegacyProjectListGetTests
 {
-	private readonly LegacyProjectController _subject;
+	private readonly ProjectController _subject;
 	private readonly AcademisationContext _context;
 	private readonly Fixture _fixture = new();
 
@@ -25,7 +25,7 @@ public class LegacyProjectListGetTests
 		IProjectListGetDataQuery projectGetDataQuery = new ProjectListGetDataQuery(_context);
 		ILegacyProjectListGetQuery legacyProjectGetQuery = new LegacyProjectListGetQuery(projectGetDataQuery);
 
-		_subject = new LegacyProjectController(Mock.Of<ILegacyProjectGetQuery>(), legacyProjectGetQuery,
+		_subject = new ProjectController(Mock.Of<ILegacyProjectGetQuery>(), legacyProjectGetQuery,
 			Mock.Of<IProjectGetStatusesQuery>(), Mock.Of<ILegacyProjectUpdateCommand>(), Mock.Of<ILegacyProjectAddNoteCommand>(),
 			Mock.Of<ILegacyProjectDeleteNoteCommand>(),Mock.Of<ICreateSponsoredProjectCommand>());
 	}

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectUpdateTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectUpdateTests.cs
@@ -45,7 +45,7 @@ public class ProjectUpdateTests
 	public async Task ProjectExists___FullProjectIsUpdated()
 	{
 		// Arrange
-		var legacyProjectController = new LegacyProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
+		var legacyProjectController = new ProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
 			Mock.Of<IProjectGetStatusesQuery>(), _legacyProjectUpdateCommand, Mock.Of<ILegacyProjectAddNoteCommand>(),
 			Mock.Of<ILegacyProjectDeleteNoteCommand>(), Mock.Of<ICreateSponsoredProjectCommand>());
 		var existingProject = _fixture.Create<ProjectState>();
@@ -73,7 +73,7 @@ public class ProjectUpdateTests
 	public async Task ProjectExists_FullProjectIsReturnedOnGet()
 	{
 		// Arrange
-		var legacyProjectController = new LegacyProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
+		var legacyProjectController = new ProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
 			Mock.Of<IProjectGetStatusesQuery>(), _legacyProjectUpdateCommand, Mock.Of<ILegacyProjectAddNoteCommand>(),
 			Mock.Of<ILegacyProjectDeleteNoteCommand>(), Mock.Of<ICreateSponsoredProjectCommand>());
 		var existingProject = _fixture.Create<ProjectState>();
@@ -103,7 +103,7 @@ public class ProjectUpdateTests
 	public async Task ProjectExists___PartialProjectIsUpdated()
 	{
 		// Arrange
-		var legacyProjectController = new LegacyProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
+		var legacyProjectController = new ProjectController(_legacyProjectGetQuery, Mock.Of<ILegacyProjectListGetQuery>(),
 			Mock.Of<IProjectGetStatusesQuery>(), _legacyProjectUpdateCommand, Mock.Of<ILegacyProjectAddNoteCommand>(),
 			Mock.Of<ILegacyProjectDeleteNoteCommand>(), Mock.Of<ICreateSponsoredProjectCommand>());
 		var existingProject = _fixture.Create<ProjectState>();

--- a/Dfe.Academies.Academisation.WebApi/Controllers/ProjectController.cs
+++ b/Dfe.Academies.Academisation.WebApi/Controllers/ProjectController.cs
@@ -13,7 +13,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 	[Route("legacy/")]
 	[ApiController]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	public class LegacyProjectController : ControllerBase
+	public class ProjectController : ControllerBase
 	{
 		private readonly ILegacyProjectAddNoteCommand _legacyProjectAddNoteCommand;
 		private readonly ILegacyProjectDeleteNoteCommand _legacyProjectDeleteNoteCommand;
@@ -23,7 +23,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 		private readonly IProjectGetStatusesQuery _projectGetStatusesQuery;
 		private readonly ICreateSponsoredProjectCommand _createSponsoredProjectCommand;
 
-		public LegacyProjectController(ILegacyProjectGetQuery legacyProjectGetQuery,
+		public ProjectController(ILegacyProjectGetQuery legacyProjectGetQuery,
 									   ILegacyProjectListGetQuery legacyProjectListGetQuery,
 									   IProjectGetStatusesQuery projectGetStatusesQuery,
 									   ILegacyProjectUpdateCommand legacyProjectUpdateCommand,
@@ -167,7 +167,7 @@ namespace Dfe.Academies.Academisation.WebApi.Controllers
 				CommandSuccessResult => Created(new Uri("/legacy/project/", UriKind.Relative), null),
 				NotFoundCommandResult => NotFound(),
 				_ => throw new NotImplementedException()
-			};
+			}; 
 		}
 
 		/// <summary>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,5 @@
 ## 8.0.0
 * The term 'Involuntary Conversion' has been replaced with 'Sponsored Conversion'. This includes all Api endpoints. Note this release is required for the corresponding changes in the prepare-conversions application to work.
+* User Story 129594 : The Local Authority and Region for a school is now passed up to the Academisation Api during involuntary project creation. This avoids the delay in populating the two values within the Academisation Api as they're already known during the conversion process.
 
 ---


### PR DESCRIPTION
Added local authority and region to the model sent from conversions when creating an involuntary conversion.
This will store the two values in the database immediately, and if not null then the background enrichment task will skip over them.
Also renamed LegacyProjectController to ProjectController as it's not legacy. Other 'legacy' naming needs to be reviewed.