### PR TITLE
Adjust App Settings to reduce LogLevel in Development

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/appsettings.Development.json
+++ b/Dfe.Academies.Academisation.WebApi/appsettings.Development.json
@@ -2,7 +2,7 @@
 	"DetailedErrors": true,
 	"Logging": {
 		"LogLevel": {
-			"Default": "Debug",
+			"Default": "Information",
 			"Microsoft.AspNetCore": "Warning",
 			"Microsoft.EntityFrameworkCore": "Warning"
 		}

--- a/Dfe.Academies.Academisation.WebApi/appsettings.json
+++ b/Dfe.Academies.Academisation.WebApi/appsettings.json
@@ -7,16 +7,13 @@
 		}
 	},
 	"AllowedHosts": "*",
-	"HelloWorld": {
-		"Greeting": ""
-	},
 	"AcademiesDatabaseConnectionString": "<use environment specific secrets for this setting>",
 	"AcademiesApiKey": null,
 	"AcademiesUrl": null,
 	"AuthenticationConfig": {
 		"ApiKeys": []
 	},
-  	"ApplicationInsights": {
+	"ApplicationInsights": {
 		"ConnectionString": ""
   }
 }


### PR DESCRIPTION
"Debug" log level is very noisy and shouldn't be used in a development environment by default