### PR TITLE
Configure a Log Ingestion rate alarm at >1GB/day

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -148,6 +148,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alarm_log_ingestion_gb_per_day"></a> [alarm\_log\_ingestion\_gb\_per\_day](#input\_alarm\_log\_ingestion\_gb\_per\_day) | Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to 1GB/day) | `number` | `1` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created | `list(string)` | n/a | yes |
 | <a name="input_cdn_frontdoor_enable_rate_limiting"></a> [cdn\_frontdoor\_enable\_rate\_limiting](#input\_cdn\_frontdoor\_enable\_rate\_limiting) | Enable CDN Front Door Rate Limiting. This will create a WAF policy, and CDN security policy. For pricing reasons, there will only be one WAF policy created. | `bool` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -51,4 +51,6 @@ module "azure_container_apps_hosting" {
   existing_logic_app_workflow                  = local.existing_logic_app_workflow
   existing_network_watcher_name                = local.existing_network_watcher_name
   existing_network_watcher_resource_group_name = local.existing_network_watcher_resource_group_name
+
+  alarm_log_ingestion_gb_per_day = local.alarm_log_ingestion_gb_per_day
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -47,4 +47,5 @@ locals {
   statuscake_contact_group_name                   = var.statuscake_contact_group_name
   statuscake_contact_group_integrations           = var.statuscake_contact_group_integrations
   statuscake_contact_group_email_addresses        = var.statuscake_contact_group_email_addresses
+  alarm_log_ingestion_gb_per_day                  = var.alarm_log_ingestion_gb_per_day
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -276,3 +276,9 @@ variable "statuscake_contact_group_email_addresses" {
   type        = list(string)
   default     = []
 }
+
+variable "alarm_log_ingestion_gb_per_day" {
+  description = "Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to 1GB/day)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
This app has a history of excessive log ingestion which causes a significant spike in cost. 

Setting a sensible alarm threshold of 1GB/day should allow us to have more visibility sooner and allow us to intervene in a runaway scenario