### PR TITLE
Deploy user assigned managed identity

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -136,7 +136,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.4.4 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.4.5 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.2.2 |
 | <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.2 |
 
@@ -190,6 +190,9 @@ No resources.
 | <a name="input_mssql_server_admin_password"></a> [mssql\_server\_admin\_password](#input\_mssql\_server\_admin\_password) | The local administrator password for the MSSQL server | `string` | n/a | yes |
 | <a name="input_mssql_server_public_access_enabled"></a> [mssql\_server\_public\_access\_enabled](#input\_mssql\_server\_public\_access\_enabled) | Enable public internet access to your MSSQL instance. Be sure to specify 'mssql\_firewall\_ipv4\_allow\_list' to restrict inbound connections | `bool` | `false` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_registry_admin_enabled"></a> [registry\_admin\_enabled](#input\_registry\_admin\_enabled) | Do you want to enable access key based authentication for your Container Registry? | `bool` | `true` | no |
+| <a name="input_registry_managed_identity_assign_role"></a> [registry\_managed\_identity\_assign\_role](#input\_registry\_managed\_identity\_assign\_role) | Assign the 'AcrPull' Role to the Container App User-Assigned Managed Identity. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'AcrPull' Role to the identity | `bool` | `false` | no |
+| <a name="input_registry_use_managed_identity"></a> [registry\_use\_managed\_identity](#input\_registry\_use\_managed\_identity) | Create a User-Assigned Managed Identity for the Container App. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'AcrPull' Role to the identity | `bool` | `true` | no |
 | <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | `"00000000000000000000000000000"` | no |
 | <a name="input_statuscake_contact_group_email_addresses"></a> [statuscake\_contact\_group\_email\_addresses](#input\_statuscake\_contact\_group\_email\_addresses) | List of email address that should receive notifications from StatusCake | `list(string)` | `[]` | no |
 | <a name="input_statuscake_contact_group_integrations"></a> [statuscake\_contact\_group\_integrations](#input\_statuscake\_contact\_group\_integrations) | List of Integration IDs to connect to your Contact Group | `list(string)` | `[]` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v1.4.4"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v1.4.5"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -8,7 +8,10 @@ module "azure_container_apps_hosting" {
 
   virtual_network_address_space = local.virtual_network_address_space
 
-  enable_container_registry = local.enable_container_registry
+  enable_container_registry             = local.enable_container_registry
+  registry_admin_enabled                = local.registry_admin_enabled
+  registry_use_managed_identity         = local.registry_use_managed_identity
+  registry_managed_identity_assign_role = local.registry_managed_identity_assign_role
 
   image_name                             = local.image_name
   container_command                      = local.container_command

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,6 +5,9 @@ locals {
   tags                                            = var.tags
   virtual_network_address_space                   = var.virtual_network_address_space
   enable_container_registry                       = var.enable_container_registry
+  registry_admin_enabled                          = var.registry_admin_enabled
+  registry_use_managed_identity                   = var.registry_use_managed_identity
+  registry_managed_identity_assign_role           = var.registry_managed_identity_assign_role
   image_name                                      = var.image_name
   container_command                               = var.container_command
   container_secret_environment_variables          = var.container_secret_environment_variables

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,24 @@ variable "enable_container_registry" {
   type        = bool
 }
 
+variable "registry_admin_enabled" {
+  description = "Do you want to enable access key based authentication for your Container Registry?"
+  type        = bool
+  default     = true
+}
+
+variable "registry_use_managed_identity" {
+  description = "Create a User-Assigned Managed Identity for the Container App. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'AcrPull' Role to the identity"
+  type        = bool
+  default     = true
+}
+
+variable "registry_managed_identity_assign_role" {
+  description = "Assign the 'AcrPull' Role to the Container App User-Assigned Managed Identity. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'AcrPull' Role to the identity"
+  type        = bool
+  default     = false
+}
+
 variable "image_name" {
   description = "Image name"
   type        = string


### PR DESCRIPTION
Granting a User-Assigned Managed Identity the 'AcrPull' role and using that to authenticate with Azure Container Registry follows Microsoft's best practice recommendation instead of using an admin username/password.