### PR TITLE
Annotate App Insights for each deployment release

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -51,6 +51,7 @@ jobs:
       docker-image-name: 'aca-app'
       docker-build-file-name: './Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
+      annotate-release: ${{ needs.set-env.outputs.environment == 'development' }}
       docker-build-args: |
         COMMIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
     secrets:


### PR DESCRIPTION
This is currently limited to Dev for testing.

This change adds an extra step post-deployment to record a custom deployment event in App Insights with the SHA that corresponds with the release. This is useful so we can review performance metrics before and after a release