### PR TITLE
Allow unauthenticated access to the health check route

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/Middleware/ApiKeyAuthenticationMiddleware.cs
+++ b/Dfe.Academies.Academisation.WebApi/Middleware/ApiKeyAuthenticationMiddleware.cs
@@ -18,6 +18,12 @@ public class ApiKeyAuthenticationMiddleware
 	}
 	public async Task InvokeAsync(HttpContext context)
 	{
+		// Bypass API Key requirement for health check route
+		if (context.Request.Path == "/healthcheck") {
+			await _next(context);
+			return;
+		}
+
 		if (!context.Request.Headers.TryGetValue(ApiKeyHeader, out var requestApiKey))
 		{
 			context.Response.StatusCode = StatusCodes.Status401Unauthorized;


### PR DESCRIPTION
- The healthcheck endpoint is already registered in Program.cs
- We should switch our monitoring from using the swagger index.html file to use the healthcheck endpoint instead. We can only do this if the route is accessible without authentication