### PR TITLE
Set HTTP user agent header

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/Program.cs
+++ b/Dfe.Academies.Academisation.WebApi/Program.cs
@@ -213,6 +213,7 @@ builder.Services.AddHttpClient("AcademiesApi", (sp, client) =>
 	{
 		client.BaseAddress = new Uri(url);
 		client.DefaultRequestHeaders.Add("ApiKey", configuration.GetValue<string>("AcademiesApiKey"));
+		client.DefaultRequestHeaders.Add("User-Agent", "AcademisationApi/1.0");
 	}
 	else
 	{


### PR DESCRIPTION
Set a custom User-Agent HTTP Header so that traffic can be segmented when running reports against the downstream APIs