### PR TITLE
Modify payload and test expectations to match actual behaviour

### DIFF
--- a/CypressTests/cypress/e2e/Transfers-MAT.cy.js
+++ b/CypressTests/cypress/e2e/Transfers-MAT.cy.js
@@ -600,11 +600,11 @@ describe('Academisation API Testing - Transfers MAT Projects', () => {
       expect(response.body.benefits.anyRisks).to.be.true
 
       // CHECK SCHOOL ADDITIONAL DETAILS RETURNING CORRECTLY IN RESPONSE
-      expect(response.body.transferringAcademies[0].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
       cy.log(URN)
     })
   })
@@ -696,11 +696,11 @@ describe('Academisation API Testing - Transfers MAT Projects', () => {
       expect(response.body.benefits.isCompleted).to.be.true
       expect(response.body.benefits.anyRisks).to.be.true
 
-      expect(response.body.transferringAcademies[0].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
 
       // CHECKING THE NEW SET TRUST RETURNS HERE
       expect(response.body.generalInformation).to.have.property('recommendation', 'recommendationString value')
@@ -796,11 +796,11 @@ describe('Academisation API Testing - Transfers MAT Projects', () => {
       expect(response.body.benefits.isCompleted).to.be.true
       expect(response.body.benefits.anyRisks).to.be.true
 
-      expect(response.body.transferringAcademies[0].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
-      expect(response.body.transferringAcademies[0].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].pupilNumbersAdditionalInformation).to.equal('pupilNumbersAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].latestOfstedReportAdditionalInformation).to.equal('latestOfstedReportAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage2PerformanceAdditionalInformation).to.equal('keyStage2PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage4PerformanceAdditionalInformation).to.equal('KeyStage4PerformanceAdditionalInformation value')
+      expect(response.body.transferringAcademies[1].keyStage5PerformanceAdditionalInformation).to.equal('keyStage5PerformanceAdditionalInformation value')
 
       expect(response.body.generalInformation).to.have.property('recommendation', 'recommendationString value')
       expect(response.body.generalInformation).to.have.property('author', 'authorString value')

--- a/CypressTests/cypress/fixtures/payloads/Transfers/AuthorisedUserCanSetAdditionalSchoolData.spec.js
+++ b/CypressTests/cypress/fixtures/payloads/Transfers/AuthorisedUserCanSetAdditionalSchoolData.spec.js
@@ -1,7 +1,7 @@
 const AuthorisedUserCanSetAdditionalSchoolDataPayload
 = {
   urn: Cypress.env('URN'),
-  transferringAcademyUkprn: 10066875,
+  transferringAcademyUkprn: 10066876,
   latestOfstedReportAdditionalInformation: 'latestOfstedReportAdditionalInformation value',
   pupilNumbersAdditionalInformation: 'pupilNumbersAdditionalInformation value',
   keyStage2PerformanceAdditionalInformation: 'keyStage2PerformanceAdditionalInformation value',


### PR DESCRIPTION
Updates the UKPRN being updated with additional data used by both MAT and SAT Cypress tests. This means both tests can use the same payload properly.

As a result, MAT tests have been updated to check the correct part of the response payload on some tests

Successful run can be seen here: [Run Cypress tests #4](https://github.com/DFE-Digital/academies-academisation-api/actions/runs/10832481262/job/30056942251)