### PR TITLE
fix to only bring back projects to enrich which have a trust reference number

### DIFF
--- a/Dfe.Academies.Academisation.Data/Repositories/ConversionProjectRepository.cs
+++ b/Dfe.Academies.Academisation.Data/Repositories/ConversionProjectRepository.cs
@@ -92,7 +92,13 @@ namespace Dfe.Academies.Academisation.Data.Repositories
 		public async Task<IEnumerable<IProject>?> GetIncompleteProjects()
 		{
 			var createdProjectState = await _context.Projects
-				.Where(p => string.IsNullOrEmpty(p.Details.LocalAuthority) || string.IsNullOrEmpty(p.Details.Region) || string.IsNullOrEmpty(p.Details.SchoolPhase) || string.IsNullOrEmpty(p.Details.SchoolType) || (p.Details.TrustUkprn == null && p.Details.IsFormAMat == false))
+				.Where(p => 
+				string.IsNullOrEmpty(p.Details.LocalAuthority) || 
+				string.IsNullOrEmpty(p.Details.Region) || 
+				string.IsNullOrEmpty(p.Details.SchoolPhase) || 
+				string.IsNullOrEmpty(p.Details.SchoolType) || 
+				// we need projects that have a trust associated that aren't form a mat that require a trust ukprn
+				(p.Details.TrustUkprn == null && p.Details.IsFormAMat == false && p.Details.TrustReferenceNumber != null))
 				.ToListAsync();
 
 			return createdProjectState;

--- a/Dfe.Academies.Academisation.Service/Commands/Legacy/Project/EnrichProjectCommand.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/Legacy/Project/EnrichProjectCommand.cs
@@ -1,15 +1,11 @@
-﻿using System.Net.Http.Json;
-using Dfe.Academies.Academisation.Data.Http;
-using Dfe.Academies.Academisation.Data.ProjectAggregate;
+﻿using Dfe.Academies.Academisation.Data.ProjectAggregate;
 using Dfe.Academies.Academisation.Domain.ApplicationAggregate;
 using Dfe.Academies.Academisation.IService.Commands.Legacy.Project;
 using Dfe.Academies.Academisation.IService.Query;
-using Dfe.Academies.Academisation.IService.ServiceModels.Academies;
 using Dfe.Academies.Academisation.IService.ServiceModels.Legacy.ProjectAggregate;
 using Dfe.Academies.Academisation.Service.Mappers.Legacy.ProjectAggregate;
 using Dfe.Academies.Contracts.V4.Establishments;
 using Dfe.Academies.Contracts.V4.Trusts;
-using Dfe.Academisation.CorrelationIdMiddleware;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.Academies.Academisation.Service.Commands.Legacy.Project


### PR DESCRIPTION
- we were trying to enrich projects with a trust ukprn but didn't exclude ones that did not a trust reference to look up the ukprn

