### PR TITLE
Add DbContextChecks to Health Checks

### DIFF
--- a/Dfe.Academies.Academisation.WebApi/Dfe.Academies.Academisation.WebApi.csproj
+++ b/Dfe.Academies.Academisation.WebApi/Dfe.Academies.Academisation.WebApi.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.24.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/Dfe.Academies.Academisation.WebApi/Program.cs
+++ b/Dfe.Academies.Academisation.WebApi/Program.cs
@@ -97,8 +97,6 @@ builder.Services.AddSwaggerGen(config =>
 	if (File.Exists(descriptionsPath)) config.IncludeXmlComments(descriptionsPath);
 });
 
-builder.Services.AddHealthChecks();
-
 builder.Services.AddOptions<AuthenticationConfig>();
 var apiKeysConfiguration = builder.Configuration.GetSection("AuthenticationConfig");
 builder.Services.Configure<AuthenticationConfig>(apiKeysConfiguration);
@@ -156,6 +154,9 @@ builder.Services.AddDbContext<AcademisationContext>(options =>
 #endif
 	}
 );
+
+builder.Services.AddHealthChecks()
+	.AddDbContextCheck<AcademisationContext>("Academisation Database");
 
 builder.Services.AddSwaggerGen();
 builder.Services.ConfigureOptions<SwaggerOptions>();


### PR DESCRIPTION
This will ensure that the healthcheck endpoint correctly reports the status of the service if a database connection faults