### PR TITLE
POC on locking rows so they are not sent twice

### DIFF
--- a/Dfe.Academies.Academisation.Data/AcademisationContext.cs
+++ b/Dfe.Academies.Academisation.Data/AcademisationContext.cs
@@ -384,6 +384,7 @@ public class AcademisationContext(DbContextOptions<AcademisationContext> options
 		projectConfiguration.HasKey(x => x.Id);
 		projectConfiguration.Property(d => d.CreatedOn).HasColumnName("CreatedOn");
 		projectConfiguration.Property(d => d.FormAMatProjectId).HasColumnName("FormAMatProjectId");
+		projectConfiguration.Property(d => d.LockedUntil).HasDefaultValueSql("GETUTCDATE()");
 		projectConfiguration.OwnsOne(x => x.Details, pd =>
 		{
 			pd.Property(d => d.ViabilityIssues).HasColumnName("ViabilityIssues");

--- a/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
+++ b/Dfe.Academies.Academisation.Domain/ProjectAggregate/Project.cs
@@ -52,6 +52,8 @@ public class Project : Entity, IProject, IAggregateRoot
 
 	public bool ProjectSentToComplete { get; set; } = false;
 
+	public DateTime LockedUntil { get; private set; }
+
 	// Create from A2b 
 	public static CreateResult Create(IApplication application)
 	{
@@ -637,5 +639,9 @@ public class Project : Entity, IProject, IAggregateRoot
 		// Update the LastModifiedOn property to the current time to indicate the object has been modified
 		this.LastModifiedOn = DateTime.UtcNow;
 	}
-	
+
+	public void SetLockedUntil(DateTime dateTime)
+	{
+		this.LockedUntil = dateTime;
+	}
 }

--- a/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
+++ b/Dfe.Academies.Academisation.IDomain/ProjectAggregate/IProject.cs
@@ -17,6 +17,7 @@ public interface IProject
 	public bool ProjectSentToComplete { get; }
 	DateTime CreatedOn { get; }
 	DateTime LastModifiedOn { get; }
+	DateTime LockedUntil { get; }
 
 	public IReadOnlyCollection<IProjectNote> Notes { get; }
 	public IReadOnlyCollection<ISchoolImprovementPlan> SchoolImprovementPlans { get; }


### PR DESCRIPTION
- simple solution to preventing duplicates being sent
- as the entire command handler pipeline is wrapped in a transaction it should stop another process editing the locked until field until the process has finished
- would require testing in a multi container environment to prove
- needs expanding out to the other commands 