### PR TITLE
Use an initcontainer to run EF Migrations

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,59 +14,77 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
 
+env:
+  IMAGE_NAME: aca-app
+
 jobs:
   set-env:
     name: Determine environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       environment: ${{ steps.var.outputs.environment }}
-      branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
-      checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
+      image-name: ${{ steps.var.outputs.image-name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - id: var
         run: |
-          GIT_REF=${{ github.ref_name }}
-          GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
-          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
-          echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
-          echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
+          echo "image-name=${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
 
-  deploy-image:
+  build:
+    name: Build
+    needs: [ set-env ]
+    permissions:
+      packages: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      docker-build-args: CI=true
+
+  import:
+    name: Import
+    needs: [ set-env, build ]
     permissions:
       id-token: write
-      contents: read
-      packages: write
-    name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
-    needs: [ set-env ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
     with:
-      docker-image-name: 'aca-app'
-      docker-build-file-name: './Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
-      annotate-release: true
-      docker-build-args: |
-        COMMIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
     secrets:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
       azure-acr-name: ${{ secrets.ACR_NAME }}
+
+  deploy:
+    name: Deploy
+    needs: [ set-env, import ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/deploy.yml@v4.1.0
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      annotate-release: true
+    secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-aca-client-id: ${{ secrets.ACA_CLIENT_ID }}
       azure-aca-name: ${{ secrets.ACA_CONTAINERAPP_NAME }}
       azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+      azure-acr-name: ${{ secrets.ACR_NAME }}
 
   create-tag:
     name: Tag and release
-    needs: set-env
+    needs: [ deploy, set-env ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -100,7 +118,7 @@ jobs:
   cypress-tests:
     name: Run Cypress tests
     if: needs.set-env.outputs.environment == 'test' || needs.set-env.outputs.environment == 'development'
-    needs: [ deploy-image, set-env ]
+    needs: [ deploy, set-env ]
     uses: ./.github/workflows/cypress-tests.yml
     with:
       environment: ${{ needs.set-env.outputs.environment }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -44,10 +44,23 @@ jobs:
     permissions:
       packages: write
     uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
+        include:
+          - stage: "final"
+            tag-prefix: ""
+          - stage: "initcontainer"
+            tag-prefix: "init-"
     with:
       environment: ${{ needs.set-env.outputs.environment }}
       docker-image-name: ${{ needs.set-env.outputs.image-name }}
       docker-build-args: CI=true
+      docker-build-target: ${{ matrix.stage }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
 
   import:
     name: Import
@@ -55,9 +68,21 @@ jobs:
     permissions:
       id-token: write
     uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
+        include:
+          - stage: "final"
+            tag-prefix: ""
+          - stage: "initcontainer"
+            tag-prefix: "init-"
     with:
       environment: ${{ needs.set-env.outputs.environment }}
       docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
     secrets:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,4 +28,5 @@ jobs:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha
+          target: ${{ matrix.stage }}
           push: false

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -2,11 +2,17 @@ name: Scan Docker image
 
 on:
   push:
-    branches: main
+    branches: [main]
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
     outputs:
       image: ${{ steps.build.outputs.imageid }}
     steps:
@@ -24,15 +30,16 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha
+          target: ${{ matrix.stage }}
           push: false
 
       - name: Export docker image as tar
-        run: docker save -o ${{ github.ref_name }}.tar ${{ steps.build.outputs.imageid }}
+        run: docker save -o ${{ matrix.stage }}-${{ github.ref_name }}.tar ${{ steps.build.outputs.imageid }}
 
       - name: Scan Docker image for CVEs
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          input: ${{ github.ref_name }}.tar
+          input: ${{ matrix.stage }}-${{ github.ref_name }}.tar
           format: 'sarif'
           output: 'trivy-results.sarif'
           limit-severities-for-sarif: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=efbuilder /sql /sql
 RUN chown "$APP_UID" "/sql" -R
 USER $APP_UID
 
-# Install SQL tools to allow migrations to be run
+# Build a runtime environment
 FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final
 WORKDIR /app
 LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/academies-academisation-api"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,29 +23,26 @@ RUN ["dotnet", "restore", "Dfe.Academies.Academisation.WebApi"]
 RUN ["dotnet", "build", "Dfe.Academies.Academisation.WebApi", "--no-restore", "-c", "Release"]
 RUN ["dotnet", "publish", "Dfe.Academies.Academisation.WebApi", "--no-build", "-o", "/app"]
 
-RUN ["dotnet", "new", "tool-manifest"]
-RUN ["dotnet", "tool", "install", "dotnet-ef", "--version", "8.0.11"]
-RUN ["mkdir", "-p", "/app/SQL"]
-RUN ["dotnet", "restore", "Dfe.Academies.Academisation.WebApi"]
-RUN ["dotnet", "build", "Dfe.Academies.Academisation.WebApi", "--no-restore"]
-RUN ["dotnet", "ef", "migrations", "script", "--output", "/app/SQL/DbMigrationScript.sql", "--idempotent", "-p", "/build/Dfe.Academies.Academisation.Data", "-s", "/build/Dfe.Academies.Academisation.WebApi", "-c", "AcademisationContext", "--no-build"]
-RUN ["touch", "/app/SQL/DbMigrationScriptOutput.txt"]
+# Generate an Entity Framework bundle
+FROM build AS efbuilder
+ENV PATH=$PATH:/root/.dotnet/tools
+RUN ["mkdir", "/sql"]
+RUN ["dotnet", "tool", "install", "--global", "dotnet-ef"]
+RUN ["dotnet", "ef", "migrations", "bundle", "-r", "linux-x64", "-p", "Dfe.Academies.Academisation.Data", "-s", "Dfe.Academies.Academisation.WebApi", "-c", "AcademisationContext", "--configuration", "Release", "--no-build", "-o", "/sql/migratedb"]
+
+# Create a runtime environment for Entity Framework
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS initcontainer
+WORKDIR /sql
+COPY --from=efbuilder /app/appsettings.json /Dfe.Academies.Academisation/
+COPY --from=efbuilder /sql /sql
+RUN chown "$APP_UID" "/sql" -R
+USER $APP_UID
 
 # Install SQL tools to allow migrations to be run
-FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS base
-RUN curl "https://packages.microsoft.com/config/rhel/9/prod.repo" | tee /etc/yum.repos.d/mssql-release.repo
-ENV ACCEPT_EULA=Y
-RUN ["tdnf", "update"]
-RUN ["tdnf", "install", "-y", "mssql-tools18"]
-RUN ["tdnf", "clean", "all"]
-
-# Build a runtime environment
-FROM base AS runtime
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final
 WORKDIR /app
 LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/academies-academisation-api"
 COPY --from=build /app /app
 COPY ./script/webapi-docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN ["chmod", "+x", "/app/docker-entrypoint.sh"]
-RUN ["touch", "/app/SQL/DbMigrationScriptOutput.txt"]
-RUN chown "$APP_UID" "/app/SQL" -R
 USER $APP_UID

--- a/script/webapi-docker-entrypoint.sh
+++ b/script/webapi-docker-entrypoint.sh
@@ -4,22 +4,4 @@
 set -e
 set -o pipefail
 
-AcademiesDatabaseConnectionString=${AcademiesDatabaseConnectionString:?}
-
-declare -A mysqlconn
-
-for keyvaluepair in $(echo "$AcademiesDatabaseConnectionString" | sed "s/ //g; s/;/ /g")
-do
-  IFS=" " read -r -a ARR <<< "${keyvaluepair//=/ }"
-  mysqlconn[${ARR[0]}]=${ARR[1]}
-done
-
-echo "Running database migrations ..."
-until /opt/mssql-tools18/bin/sqlcmd -S "${mysqlconn[Server]}" -U "${mysqlconn[UserId]}" -P "${mysqlconn[Password]}" -d "${mysqlconn[Database]}" -C -I -i /app/SQL/DbMigrationScript.sql -o /app/SQL/DbMigrationScriptOutput.txt
-do
-  cat /app/SQL/DbMigrationScriptOutput.txt
-  echo "Retrying database migrations ..."
-  sleep 5
-done
-
 exec "$@"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -185,6 +185,7 @@ No resources.
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | `false` | no |
 | <a name="input_enable_health_insights_api"></a> [enable\_health\_insights\_api](#input\_enable\_health\_insights\_api) | Deploys a Function App that exposes the last 3 HTTP Web Tests via an API endpoint. 'enable\_app\_insights\_integration' and 'enable\_monitoring' must be set to 'true'. | `bool` | `false` | no |
+| <a name="input_enable_init_container"></a> [enable\_init\_container](#input\_enable\_init\_container) | Deploy an Init Container. Init containers run before the primary app container and are used to perform initialization tasks such as downloading data or preparing the environment | `bool` | `false` | no |
 | <a name="input_enable_logstash_consumer"></a> [enable\_logstash\_consumer](#input\_enable\_logstash\_consumer) | Create an Event Hub consumer group for Logstash | `bool` | `false` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | n/a | yes |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with a private endpoint within the virtual network | `bool` | n/a | yes |
@@ -196,6 +197,8 @@ No resources.
 | <a name="input_health_insights_api_cors_origins"></a> [health\_insights\_api\_cors\_origins](#input\_health\_insights\_api\_cors\_origins) | List of hostnames that are permitted to contact the Health insights API | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_health_insights_api_ipv4_allow_list"></a> [health\_insights\_api\_ipv4\_allow\_list](#input\_health\_insights\_api\_ipv4\_allow\_list) | List of IPv4 addresses that are permitted to contact the Health insights API | `list(string)` | `[]` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
+| <a name="input_init_container_command"></a> [init\_container\_command](#input\_init\_container\_command) | Container command for the Init Container | `list(any)` | `[]` | no |
+| <a name="input_init_container_image"></a> [init\_container\_image](#input\_init\_container\_image) | Image name for the Init Container. Leave blank to use the same Container image from the primary app | `string` | `""` | no |
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
 | <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -71,4 +71,7 @@ module "azure_container_apps_hosting" {
   existing_network_watcher_resource_group_name = local.existing_network_watcher_resource_group_name
 
   alarm_log_ingestion_gb_per_day = local.alarm_log_ingestion_gb_per_day
+  enable_init_container          = local.enable_init_container
+  init_container_image           = local.init_container_image
+  init_container_command         = local.init_container_command
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -65,4 +65,7 @@ locals {
   cdn_frontdoor_vdp_destination_hostname          = var.cdn_frontdoor_vdp_destination_hostname
   dns_alias_records                               = var.dns_alias_records
   monitor_http_availability_fqdn                  = var.monitor_http_availability_fqdn
+  enable_init_container                           = var.enable_init_container
+  init_container_image                            = var.init_container_image
+  init_container_command                          = var.init_container_command
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -442,3 +442,21 @@ variable "dns_alias_records" {
   )
   default = {}
 }
+
+variable "enable_init_container" {
+  description = "Deploy an Init Container. Init containers run before the primary app container and are used to perform initialization tasks such as downloading data or preparing the environment"
+  type        = bool
+  default     = false
+}
+
+variable "init_container_image" {
+  description = "Image name for the Init Container. Leave blank to use the same Container image from the primary app"
+  type        = string
+  default     = ""
+}
+
+variable "init_container_command" {
+  description = "Container command for the Init Container"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
* Use an `initContainer` to launch an Entity Framework bundle as a preflight container before the main app boots
* This makes the final image smaller and safer because it will no longer container any SQL related data
* Segmenting the workflow into parallel builds ensures the initContainer gets built and imported before the main container gets restarted to avoid any race conditions 