### PR TITLE
Launch background task worker in Azure

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -190,6 +190,7 @@ No resources.
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | n/a | yes |
 | <a name="input_enable_monitoring_traces"></a> [enable\_monitoring\_traces](#input\_enable\_monitoring\_traces) | Monitor App Insights traces for error messages | `bool` | `true` | no |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with a private endpoint within the virtual network | `bool` | n/a | yes |
+| <a name="input_enable_worker_container"></a> [enable\_worker\_container](#input\_enable\_worker\_container) | Conditionally launch a worker container. This container uses the same image and environment variables as the default container app, but allows a different container command to be run. The worker container does not expose any ports. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_eventhub_export_log_analytics_table_names"></a> [eventhub\_export\_log\_analytics\_table\_names](#input\_eventhub\_export\_log\_analytics\_table\_names) | List of Log Analytics table names that you want to export to Event Hub. See https://learn.microsoft.com/en-gb/azure/azure-monitor/logs/logs-data-export?tabs=portal#supported-tables for a list of supported tables | `list(string)` | `[]` | no |
 | <a name="input_existing_logic_app_workflow"></a> [existing\_logic\_app\_workflow](#input\_existing\_logic\_app\_workflow) | Name, and Resource Group of an existing Logic App Workflow. Leave empty to create a new Resource | <pre>object({<br/>    name : string<br/>    resource_group_name : string<br/>  })</pre> | <pre>{<br/>  "name": "",<br/>  "resource_group_name": ""<br/>}</pre> | no |
@@ -224,6 +225,9 @@ No resources.
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This ensures that tfvars are kept up to date in Key Vault. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |
+| <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | `[]` | no |
+| <a name="input_worker_container_max_replicas"></a> [worker\_container\_max\_replicas](#input\_worker\_container\_max\_replicas) | Worker ontainer max replicas | `number` | `1` | no |
+| <a name="input_worker_container_min_replicas"></a> [worker\_container\_min\_replicas](#input\_worker\_container\_min\_replicas) | Worker container min replicas | `number` | `1` | no |
 
 ## Outputs
 

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -76,4 +76,9 @@ module "azure_container_apps_hosting" {
   init_container_command         = local.init_container_command
 
   enable_monitoring_traces = local.enable_monitoring_traces
+
+  enable_worker_container       = local.enable_worker_container
+  worker_container_command      = local.worker_container_command
+  worker_container_min_replicas = local.worker_container_min_replicas
+  worker_container_max_replicas = local.worker_container_max_replicas
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -69,4 +69,8 @@ locals {
   init_container_image                            = var.init_container_image
   init_container_command                          = var.init_container_command
   enable_monitoring_traces                        = var.enable_monitoring_traces
+  enable_worker_container                         = var.enable_worker_container
+  worker_container_command                        = var.worker_container_command
+  worker_container_min_replicas                   = var.worker_container_min_replicas
+  worker_container_max_replicas                   = var.worker_container_max_replicas
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -466,3 +466,27 @@ variable "enable_monitoring_traces" {
   type        = bool
   default     = true
 }
+
+variable "enable_worker_container" {
+  description = "Conditionally launch a worker container. This container uses the same image and environment variables as the default container app, but allows a different container command to be run. The worker container does not expose any ports."
+  type        = bool
+  default     = false
+}
+
+variable "worker_container_command" {
+  description = "Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect."
+  type        = list(string)
+  default     = []
+}
+
+variable "worker_container_min_replicas" {
+  description = "Worker container min replicas"
+  type        = number
+  default     = 1
+}
+
+variable "worker_container_max_replicas" {
+  description = "Worker ontainer max replicas"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
We want to run a single worker replica that launches from the same docker image but is responsible for background tasks instead of receiving frontend traffic. The differing behaviour is based on the value of an environment variable that is set at runtime.

Ingress must be disabled so a worker container is more suitable than a custom container app.

```
INFO: Successfully connected to container: 'main'.
app [ /app ]$ printenv | grep Complete
SendProjectsToComplete=false
```

```
INFO: Successfully connected to container: 'worker'.
app [ /app ]$ printenv | grep Complete
SendProjectsToComplete=true
```

[User Story 205493](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205493): Change academisation api so that only one instance runs background process

The Container App service principal that has Contributor on the main web app will need it's permission scope updating to enable it to restart the worker app too.