### PR TITLE
Removed path filters & wait for quality gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,8 @@ name: .NET
 
 on:
   push:
-    branches: [ "main" ]
-    paths:
-      - 'Dfe.Academies.*/**'
+    branches: [ main ]
   pull_request:
-    branches: [ "main" ]
-    types: [ opened, synchronize, reopened ]
-    paths:
-      - 'Dfe.Academies.*/**'
 
 env:
   JAVA_VERSION: 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_academies-academisation-api" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.skipJreProvisioning=true /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
+        dotnet-sonarscanner begin /d:sonar.qualitygate.wait=true /k:"DFE-Digital_academies-academisation-api" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.skipJreProvisioning=true /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
         dotnet build --no-restore
         dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
         reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./CoverageReport -reporttypes:SonarQube


### PR DESCRIPTION
* This workflow will become mandatory so we can't use path filters
* This forms part of the work to make Sonarqube a mandatory quality gate.
Introducing the `sonar.qualitygate.wait=true` parameter ensures that the scanner will wait for the report to be generated and will fail the workflow if the gate is red, rather than completing the workflow regardless of the gate