### PR TITLE
Switch to Serilog formatted logs

### DIFF
--- a/Dfe.Academies.Academisation.Seed/Dfe.Academies.Academisation.Seed.csproj
+++ b/Dfe.Academies.Academisation.Seed/Dfe.Academies.Academisation.Seed.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
   </ItemGroup>
 

--- a/Dfe.Academies.Academisation.WebApi/Dfe.Academies.Academisation.WebApi.csproj
+++ b/Dfe.Academies.Academisation.WebApi/Dfe.Academies.Academisation.WebApi.csproj
@@ -28,6 +28,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.14" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.24.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
@@ -38,7 +40,7 @@
     <ProjectReference Include="..\Dfe.Academies.Academisation.IService\Dfe.Academies.Academisation.IService.csproj" />
     <ProjectReference Include="..\Dfe.Academies.Academisation.Service\Dfe.Academies.Academisation.Service.csproj" />
   </ItemGroup>
-	
+
 	<ItemGroup>
 		<InternalsVisibleTo Include="Dfe.Academies.Academisation.IntegrationTest" />
 	</ItemGroup>

--- a/Dfe.Academies.Academisation.WebApi/appsettings.Development.json
+++ b/Dfe.Academies.Academisation.WebApi/appsettings.Development.json
@@ -1,10 +1,17 @@
 {
-	"DetailedErrors": true,
-	"Logging": {
-		"LogLevel": {
-			"Default": "Information",
-			"Microsoft.AspNetCore": "Warning",
-			"Microsoft.EntityFrameworkCore": "Warning"
-		}
-	}
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  }
 }

--- a/Dfe.Academies.Academisation.WebApi/appsettings.json
+++ b/Dfe.Academies.Academisation.WebApi/appsettings.json
@@ -1,27 +1,38 @@
 {
-	"Logging": {
-		"LogLevel": {
-			"Default": "Information",
-			"Microsoft.AspNetCore": "Error",
-			"Microsoft.EntityFrameworkCore": "Error"
-		}
-	},
-	"AllowedHosts": "*",
-	"AcademiesDatabaseConnectionString": "<use environment specific secrets for this setting>",
-	"AcademiesApiKey": null,
-	"CompleteApiKey": null,
-	"AcademiesUrl": null,
-	"CompleteUrl": null,
-	"AuthenticationConfig": {
-		"ApiKeys": []
-	},
-	"ApplicationInsights": {
-		"ConnectionString": ""
-	},
-	"RoleIds": {
-		"ConversionCreation": "",
-		"TransferCreation": "",
-		"SuperAdmin": ""
-	},
-	"SendProjectsToComplete" :  "false"
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Error",
+      "Microsoft.Hosting.Lifetime": "Error",
+      "Microsoft.AspNetCore": "Error",
+      "Microsoft.EntityFrameworkCore": "Error"
+    }
+  },
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.ApplicationInsights"
+    ],
+    "Enrich": [ "FromLogContext" ],
+    "Properties": {
+      "Application": "Dfe.Academies.Academisation.WebApi"
+    }
+  },
+  "AllowedHosts": "*",
+  "AcademiesDatabaseConnectionString": "<use environment specific secrets for this setting>",
+  "AcademiesApiKey": null,
+  "CompleteApiKey": null,
+  "AcademiesUrl": null,
+  "CompleteUrl": null,
+  "AuthenticationConfig": {
+    "ApiKeys": []
+  },
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  },
+  "RoleIds": {
+    "ConversionCreation": "",
+    "TransferCreation": "",
+    "SuperAdmin": ""
+  },
+  "SendProjectsToComplete" :  "false"
 }


### PR DESCRIPTION
This brings the API in line with other digital services in RSD by using Serilog and App insights as a log sink for traces.

I have also adjusted the default loglevels for different environments in the appsettings.json