### PR TITLE
School Support grant set to null when application submitted after deadline during PUT request

### DIFF
--- a/Dfe.Academies.Academisation.Data.UnitTest/ProjectAggregate/ProjectUpdateDataCommandTests.cs
+++ b/Dfe.Academies.Academisation.Data.UnitTest/ProjectAggregate/ProjectUpdateDataCommandTests.cs
@@ -43,7 +43,7 @@ namespace Dfe.Academies.Academisation.Data.UnitTest.ProjectAggregate
 				.With(p => p.Urn, updatedProject.Details.Urn)
 				.With(x => x.ExternalApplicationFormSaved, true)
 				.With(x => x.ExternalApplicationFormUrl, "test//url")
-				.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 23, 59, 58, DateTimeKind.Utc)) // before support grant deadline
+				.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 18, 0, 0, DateTimeKind.Utc)) // before support grant deadline
 				.Create();
 
 

--- a/Dfe.Academies.Academisation.Data.UnitTest/ProjectAggregate/ProjectUpdateDataCommandTests.cs
+++ b/Dfe.Academies.Academisation.Data.UnitTest/ProjectAggregate/ProjectUpdateDataCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using AutoFixture;
 using Dfe.Academies.Academisation.Data.ProjectAggregate;
 using Dfe.Academies.Academisation.Data.UnitTest.Contexts;
@@ -29,7 +30,8 @@ namespace Dfe.Academies.Academisation.Data.UnitTest.ProjectAggregate
 		{
 			_context.ChangeTracker.AutoDetectChangesEnabled = false;
 			// arrange
-			Project? existingProject = _fixture.Build<Project>().Create();
+			Project? existingProject = _fixture.Build<Project>()
+				.Create();
 
 			await _context.Projects.AddAsync(existingProject);
 
@@ -37,11 +39,11 @@ namespace Dfe.Academies.Academisation.Data.UnitTest.ProjectAggregate
 
 			IProject updatedProject = await _context.Projects.SingleAsync(p => p.Id == existingProject.Id);
 
-
 			ProjectDetails projectDetails = _fixture.Build<ProjectDetails>()
 				.With(p => p.Urn, updatedProject.Details.Urn)
 				.With(x => x.ExternalApplicationFormSaved, true)
 				.With(x => x.ExternalApplicationFormUrl, "test//url")
+				.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 23, 59, 58, DateTimeKind.Utc)) // before support grant deadline
 				.Create();
 
 
@@ -55,6 +57,44 @@ namespace Dfe.Academies.Academisation.Data.UnitTest.ProjectAggregate
 
 			// assert
 			Assert.True(projectDetails.Equals(updatedProject.Details));
+		}
+
+		[Fact]
+		public async Task UpdateCommand_When_Application_Received_After_SupportGrant_Deadline_Should_Have_No_SuportGrant_Data_Recorded()
+		{
+			// arrange
+			_context.ChangeTracker.AutoDetectChangesEnabled = false;
+			
+			Project? existingProject = _fixture.Build<Project>()
+				.Create();
+
+			await _context.Projects.AddAsync(existingProject);
+
+			await _context.SaveChangesAsync();
+
+			IProject updatedProject = await _context.Projects.SingleAsync(p => p.Id == existingProject.Id);
+
+			ProjectDetails projectDetails = _fixture.Build<ProjectDetails>()
+				.With(p => p.Urn, updatedProject.Details.Urn)
+				.With(x => x.ExternalApplicationFormSaved, true)
+				.With(x => x.ExternalApplicationFormUrl, "test//url")
+				.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 21, 0, 0, 0, DateTimeKind.Utc)) // after support grant deadline
+				.Create();
+
+			updatedProject.Update(projectDetails);
+
+			await _context.Projects.LoadAsync();
+
+			// act
+			await _subject.Execute(updatedProject);
+
+			// assert
+			Assert.Null(updatedProject.Details.ConversionSupportGrantAmount);
+			Assert.Null(updatedProject.Details.ConversionSupportGrantChangeReason);
+			Assert.Null(updatedProject.Details.ConversionSupportGrantType);
+			Assert.Null(updatedProject.Details.ConversionSupportGrantEnvironmentalImprovementGrant);
+			Assert.Null(updatedProject.Details.ConversionSupportGrantAmountChanged);
+			Assert.Null(updatedProject.Details.ConversionSupportGrantNumberOfSites);
 		}
 	}
 }

--- a/Dfe.Academies.Academisation.Domain.UnitTest/ProjectAggregate/ProjectUpdateTests.cs
+++ b/Dfe.Academies.Academisation.Domain.UnitTest/ProjectAggregate/ProjectUpdateTests.cs
@@ -23,7 +23,9 @@ public class ProjectUpdateTests
 		var updatedProject = _fixture.Build<ProjectDetails>()
 			.With(x => x.ExternalApplicationFormSaved, true)
 			.With(x => x.ExternalApplicationFormUrl, "test//url")
-			.With(p => p.Urn, initialProject.Urn).Without(x => x.ConversionSupportGrantChangeReason).Create();
+			.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 23, 59, 58, DateTimeKind.Utc)) // before support grant deadline
+			.With(p => p.Urn, initialProject.Urn).Without(x => x.ConversionSupportGrantChangeReason)
+			.Create();
 
 		// Act
 		var result = sut.Update(updatedProject);
@@ -39,7 +41,10 @@ public class ProjectUpdateTests
 	public void Update_WithDifferentUrn__ReturnsCommandValidationErrorResult_AndDoesNotUpdateProjectDetails()
 	{
 		// Arrange
-		var existingProject = _fixture.Create<ProjectDetails>();
+		ProjectDetails existingProject = _fixture.Build<ProjectDetails>()
+				.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 18, 0, 0, DateTimeKind.Utc)) // before support grant deadline
+				.Create();
+
 		var sut = new Project(1, existingProject);
 		var updatedProject = new ProjectDetails { Urn = 1 };
 

--- a/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectUpdateTests.cs
+++ b/Dfe.Academies.Academisation.SubcutaneousTest/ProjectAggregate/LegacyProjectUpdateTests.cs
@@ -65,7 +65,6 @@ public class ProjectUpdateTests
 		var existingProjectDetails = _fixture.Build<ProjectDetails>()
 			.With(x => x.ExternalApplicationFormSaved, true)
 			.With(x => x.ExternalApplicationFormUrl, "test//url")
-			.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 23, 59, 58, DateTimeKind.Utc)) // before support grant deadline
 			.Create();
 
 		var existingProject = new Project(101, existingProjectDetails);
@@ -79,6 +78,7 @@ public class ProjectUpdateTests
 			.With(p => p.ExternalApplicationFormSaved, existingProject.Details.ExternalApplicationFormSaved)
 			.With(p => p.IsReadOnly, existingProject.ReadOnlyDate.HasValue)
 			.With(p => p.ProjectSentToCompleteDate, existingProject.ReadOnlyDate)
+			.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 20, 15, 0, 0, DateTimeKind.Utc)) // before support grant deadline
 			// excluded from update so need to be set for equality to assert
 			.With(x => x.KeyStage2PerformanceAdditionalInformation, existingProject.Details.KeyStage2PerformanceAdditionalInformation)
 			.With(x => x.KeyStage4PerformanceAdditionalInformation, existingProject.Details.KeyStage4PerformanceAdditionalInformation)
@@ -107,7 +107,6 @@ public class ProjectUpdateTests
 		var existingProjectDetails = _fixture.Build<ProjectDetails>()
 			.With(x => x.ExternalApplicationFormSaved, true)
 			.With(x => x.ExternalApplicationFormUrl, "test//url")
-			.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 21, 0, 0, 0, DateTimeKind.Utc)) // after support grant deadline
 			.Create();
 
 		var existingProject = new Project(101, existingProjectDetails);
@@ -121,6 +120,7 @@ public class ProjectUpdateTests
 			.With(p => p.ExternalApplicationFormSaved, existingProject.Details.ExternalApplicationFormSaved)
 			.With(p => p.IsReadOnly, existingProject.ReadOnlyDate.HasValue)
 			.With(p => p.ProjectSentToCompleteDate, existingProject.ReadOnlyDate)
+			.With(x => x.ApplicationReceivedDate, new DateTime(2024, 12, 21, 5, 0, 0, DateTimeKind.Utc)) // after support grant deadline
 			.Create();
 
 		updatedProject.Notes?.Clear();


### PR DESCRIPTION
When an application has been submitted on or after the 20th December 2024, then when updating the project details, data related to Support Grant should be set to null