### PR TITLE
update decision date instead of proposed decision

### DIFF
--- a/Dfe.Academies.Academisation.Service.UnitTest/Commands/CompleteProject/CreateCompleteTransferProjectsCommandHandlerTests.cs
+++ b/Dfe.Academies.Academisation.Service.UnitTest/Commands/CompleteProject/CreateCompleteTransferProjectsCommandHandlerTests.cs
@@ -114,7 +114,7 @@ namespace Dfe.Academies.Academisation.Service.UnitTest.Commands.CompleteProject
 			_mockProjectsClient.Verify(client => client.CreateTransferProjectAsync(It.IsAny<CreateTransferProjectCommand>(), It.IsAny<CancellationToken>()), Times.Never());
 		}
 		[Fact]
-		public async Task Handle_ConversionProjectsExist_SuccessfulResponse_ReturnsCommandSuccessResult()
+		public async Task Handle_TransferProjectsExist_SuccessfulResponse_ReturnsCommandSuccessResult()
 		{
 			// Arrange
 			var command = _fixture.Create<CreateCompleteTransferProjectsCommand>();
@@ -172,7 +172,7 @@ namespace Dfe.Academies.Academisation.Service.UnitTest.Commands.CompleteProject
 			// Assert
 			Assert.IsType<CommandSuccessResult>(result);
 
-			// Verifying that the logger was called for the "Success sending conversion" case
+			// Verifying that the logger was called for the "Success sending transfer" case
 			_mockLogger.Verify(x => x.Log(LogLevel.Information,
 				// We're checking for an Information log
 				It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Success sending transfer project to complete with project urn")),
@@ -185,7 +185,7 @@ namespace Dfe.Academies.Academisation.Service.UnitTest.Commands.CompleteProject
 			_mockProjectsClient.Verify(client => client.CreateTransferProjectAsync(It.IsAny<CreateTransferProjectCommand>(), It.IsAny<CancellationToken>()), Times.Exactly(transferringAcademiesCount));
 		}
 		[Fact]
-		public async Task Handle_ConversionProjectsExist_ErrorResponse_ReturnsCommandSuccessResult()
+		public async Task Handle_TransferProjectsExist_ErrorResponse_ReturnsCommandSuccessResult()
 		{
 			// Arrange
 			var transferProjects = _fixture.CreateMany<ITransferProject>().ToList();
@@ -244,7 +244,7 @@ namespace Dfe.Academies.Academisation.Service.UnitTest.Commands.CompleteProject
 			// Assert
 			Assert.IsType<CommandSuccessResult>(result);
 
-			// Verifying that the logger was called for the "Success sending conversion" case
+			// Verifying that the logger was called for the "Error sending transfer" case
 			_mockLogger.Verify(x => x.Log(LogLevel.Error,
 				// We're checking for an Information log
 				It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error sending transfer project to complete with project urn")),

--- a/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteConversionProjectsCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteConversionProjectsCommandHandler.cs
@@ -46,7 +46,7 @@ namespace Dfe.Academies.Academisation.Service.Commands.CompleteProject
 					groupReferenceNumber = group?.ReferenceNumber;
 				}
 
-				var completeObject = CompleteConversionProjectServiceModelMapper.FromDomain(conversionProject, decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, groupReferenceNumber!);
+				var completeObject = CompleteConversionProjectServiceModelMapper.FromDomain(conversionProject, decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, groupReferenceNumber!, decision?.AdvisoryBoardDecisionDetails.AdvisoryBoardDecisionDate);
 				 
 				var response = await completeApiClientRetryFactory.CreateConversionProjectAsync(completeObject, retryPolicy, cancellationToken);
 

--- a/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteFormAMatConversionProjectsCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteFormAMatConversionProjectsCommandHandler.cs
@@ -46,7 +46,7 @@ namespace Dfe.Academies.Academisation.Service.Commands.CompleteProject
 					groupReferenceNumber = group.ReferenceNumber;
 				}
 
-				var completeObject = CompleteConversionProjectServiceModelMapper.FormAMatFromDomain(conversionProject, decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, groupReferenceNumber!);
+				var completeObject = CompleteConversionProjectServiceModelMapper.FormAMatFromDomain(conversionProject, decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, groupReferenceNumber!, decision?.AdvisoryBoardDecisionDetails.AdvisoryBoardDecisionDate);
  
 				var response = await completeApiClientRetryFactory.CreateConversionMatProjectAsync(
 						completeObject, retryPolicy, cancellationToken);

--- a/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteFormAMatTransferProjectsCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteFormAMatTransferProjectsCommandHandler.cs
@@ -53,7 +53,7 @@ namespace Dfe.Academies.Academisation.Service.Commands.CompleteProject
 				var establishment = establishments.Single(x => x.Ukprn == transferringAcademy.Ukprn);
 
 				var transferObject = CompleteTransferProjectServiceModelMapper.FormAMatFromDomain(transferProject,
-					decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, establishment.Urn);
+					decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, establishment.Urn, decision?.AdvisoryBoardDecisionDetails.AdvisoryBoardDecisionDate);
 				 
 				var response = await completeApiClientRetryFactory.CreateTransferMatProjectAsync(
 					transferObject, 

--- a/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteTransferProjectsCommandHandler.cs
+++ b/Dfe.Academies.Academisation.Service/Commands/CompleteProject/CreateCompleteTransferProjectsCommandHandler.cs
@@ -53,7 +53,7 @@ namespace Dfe.Academies.Academisation.Service.Commands.CompleteProject
 				var establishment = establishments.Single(x => x.Ukprn == transferringAcademy.Ukprn);
 
 				var transferObject = CompleteTransferProjectServiceModelMapper.FromDomain(transferProject,
-					decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, establishment.Urn);
+					decision?.AdvisoryBoardDecisionDetails.ApprovedConditionsDetails!, establishment.Urn, decision?.AdvisoryBoardDecisionDetails.AdvisoryBoardDecisionDate);
 
 				var response = await completeApiClientRetryFactory.CreateTransferProjectAsync(
 					transferObject, 

--- a/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteConversionProjectServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteConversionProjectServiceModelMapper.cs
@@ -6,7 +6,7 @@ namespace Dfe.Academies.Academisation.Service.Mappers.CompleteProjects;
 
 internal static class CompleteConversionProjectServiceModelMapper
 {
-	internal static CreateConversionProjectCommand FromDomain(IProject project, string conditions, string groupReferenceNumber)
+	internal static CreateConversionProjectCommand FromDomain(IProject project, string conditions, string groupReferenceNumber, DateTime? advisoryBoardDecisionDate)
 	{
 		var assignedUser = project.Details.AssignedUser;
 		 
@@ -16,7 +16,7 @@ internal static class CompleteConversionProjectServiceModelMapper
 		return new CreateConversionProjectCommand
 		{
 			Urn = project.Details.Urn,
-			AdvisoryBoardDate = project.Details.HeadTeacherBoardDate,
+			AdvisoryBoardDate = advisoryBoardDecisionDate,
 			AdvisoryBoardConditions = conditions,
 			ProvisionalConversionDate = project.Details.ProposedConversionDate,
 			DirectiveAcademyOrder = project.Details.AcademyTypeAndRoute?.Equals("Sponsored") ?? false,
@@ -29,7 +29,7 @@ internal static class CompleteConversionProjectServiceModelMapper
 		}; 
 	}
 
-	internal static CreateConversionMatProjectCommand FormAMatFromDomain(IProject project, string conditions, string groupReferenceNumber)
+	internal static CreateConversionMatProjectCommand FormAMatFromDomain(IProject project, string conditions, string groupReferenceNumber, DateTime? advisoryBoardDecisionDate)
 	{
 		var assignedUser = project.Details.AssignedUser;
 		 
@@ -38,7 +38,7 @@ internal static class CompleteConversionProjectServiceModelMapper
 		return new CreateConversionMatProjectCommand
 		{
 			Urn = project.Details.Urn,
-			AdvisoryBoardDate = project.Details.HeadTeacherBoardDate,
+			AdvisoryBoardDate = advisoryBoardDecisionDate,
 			AdvisoryBoardConditions = conditions,
 			ProvisionalConversionDate = project.Details.ProposedConversionDate,
 			DirectiveAcademyOrder = project.Details.AcademyTypeAndRoute?.Equals("Sponsored") ?? false,

--- a/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteTransferProjectServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteTransferProjectServiceModelMapper.cs
@@ -6,7 +6,7 @@ namespace Dfe.Academies.Academisation.Service.Mappers.CompleteProjects;
 
 internal static class CompleteTransferProjectServiceModelMapper
 {	
-	internal static CreateTransferProjectCommand FromDomain(ITransferProject project, string conditions, string urn)
+	internal static CreateTransferProjectCommand FromDomain(ITransferProject project, string conditions, string urn, DateTime? advisoryBoardDecisionDate)
 	{
 
 		string incomingTrustUkprn = project.TransferringAcademies.First().IncomingTrustUkprn!;
@@ -28,7 +28,7 @@ internal static class CompleteTransferProjectServiceModelMapper
 		return new CreateTransferProjectCommand
 		{
 			Urn = int.Parse(urn),
-			AdvisoryBoardDate = project.HtbDate,
+			AdvisoryBoardDate = advisoryBoardDecisionDate,
 			AdvisoryBoardConditions = conditions,
 			ProvisionalTransferDate = project.TargetDateForTransfer,
 			InadequateOfsted = inadequeteOfsted,

--- a/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteTransferProjectServiceModelMapper.cs
+++ b/Dfe.Academies.Academisation.Service/Mappers/CompleteProjects/CompleteTransferProjectServiceModelMapper.cs
@@ -43,7 +43,7 @@ internal static class CompleteTransferProjectServiceModelMapper
 		};
 	}
 
-	internal static CreateTransferMatProjectCommand FormAMatFromDomain(ITransferProject project, string conditions, string urn)
+	internal static CreateTransferMatProjectCommand FormAMatFromDomain(ITransferProject project, string conditions, string urn, DateTime? advisoryBoardDecisionDate)
 	{
 		string incomingName = project.TransferringAcademies.First().IncomingTrustName!;
 
@@ -63,7 +63,7 @@ internal static class CompleteTransferProjectServiceModelMapper
 		return new CreateTransferMatProjectCommand
 		{
 			 Urn = int.Parse(urn),
-			 AdvisoryBoardDate = project.HtbDate,
+			  AdvisoryBoardDate = advisoryBoardDecisionDate,
 			  AdvisoryBoardConditions = conditions,
 			  ProvisionalTransferDate = project.TargetDateForTransfer,
 			  InadequateOfsted = inadequeteOfsted,

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased](https://github.com/DFE-Digital/academies-academisation-api/compare/production-2026-04-02.577...HEAD)
 Note: remember to update unrelease section when creating a new release.
 
+### Fixed
+- [275553](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/275553) - projects not sending to complete, use the decision date instead of proposed decision date
 ---
 
 ## [9.47.1][9.47.1] - 2026-04-02


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Process%20Efficiency%201/Stories?workitem=275553


Projects aren't sending from prepare to complete. It's using the proposed decision date (which can be in the future) instead of the decision date (which must be in the past) - so failing Complete validation