### PR TITLE
update fetchScanResults to give alert count, not instant count

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -174,7 +174,7 @@ jobs:
 
   cypress-tests:
     name: Run Cypress tests
-    if: needs.set-env.outputs.environment == 'test' || needs.set-env.outputs.environment == 'development'
+    if: needs.set-env.outputs.environment == 'test'
     needs: [ deploy, set-env ]
     uses: ./.github/workflows/cypress-tests.yml
     with:
@@ -185,7 +185,7 @@ jobs:
       TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
 
   security-tests:
-    name: Run Security Scanner Tests
+    name: Run Cypress tests with OWASP ZAP
     needs: [ set-env, deploy ]
     if: needs.set-env.outputs.environment == 'development'
     uses: ./.github/workflows/security-tests.yml
@@ -201,3 +201,4 @@ jobs:
       OWASP_STORAGE_CONTAINER_NAME: ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }}
       OWASP_STORAGE_ACCOUNT_NAME: ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }}
       TEAMS_OWASP_SCAN_WEBHOOK_URL: ${{ secrets.TEAMS_OWASP_SCAN_WEBHOOK_URL }}
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -182,7 +182,7 @@ jobs:
     secrets:
       API_KEY: ${{ secrets.API_KEY }}
       URL: ${{ secrets.URL }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
 
   security-tests:
     name: Run Security Scanner Tests

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -11,7 +11,7 @@ on:
         required: true
       URL:
         required: true
-      SLACK_WEBHOOK_URL:
+      TEAMS_WEBHOOK_URL:
         required: true
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -72,8 +72,11 @@ jobs:
           name: reports-${{ inputs.environment }}-${{ matrix.browser }}
           path: CypressTests/cypress/reports/mocha
 
-      - name: Report results
+      - name: Report results to Teams
         if: always()
-        run: npm run cy:notify -- --custom-text="Environment ${{ inputs.environment }}, See more information https://github.com/DFE-Digital/academies-academisation-api/actions/runs/${{github.run_id}}"
+        run: |
+            npm run cypress:report:teams
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+            ENVIRONMENT: ${{ inputs.environment }}
+            INFORMATION_LINK: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -25,6 +25,8 @@ on:
         required: true
       TEAMS_OWASP_SCAN_WEBHOOK_URL:
         required: true
+      TEAMS_WEBHOOK_URL:
+        required: true
   workflow_dispatch:
 
 env:
@@ -126,6 +128,35 @@ jobs:
           ZAP_PORT: ${{ env.ZAP_PORT }}
         run: npm run cy:run -- --env url=$URL,apiKey=$API_KEY
 
+      - name: Upload artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: screenshots-${{ inputs.environment }}-${{ matrix.browser }}
+          path: CypressTests/cypress/screenshots
+
+      - name: Generate report
+        if: always()
+        run: |
+          mkdir mochareports
+          npm run generate:html:report
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: reports-${{ inputs.environment }}-${{ matrix.browser }}
+          path: CypressTests/cypress/reports/mocha
+
+      - name: Report Cypress results to Teams
+        if: always()
+        run: |
+            npm run cypress:report:teams
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          INFORMATION_LINK: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Azure login with OIDC
         if: ${{ !cancelled() }}
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
@@ -148,7 +179,7 @@ jobs:
               --auth-mode login \
               --overwrite
 
-      - name: Report results to Teams
+      - name: Report ZAP results to Teams
         if: ${{ !cancelled() }}
         run: npm run zap:report:teams
         env:

--- a/CypressTests/package.json
+++ b/CypressTests/package.json
@@ -12,6 +12,7 @@
     "combine:reports": "mochawesome-merge cypress/reports/mocha/*.json> mochareports/report.json",
     "create:html:report": "marge mochareports/report.json -f report -o mochareports",
     "generate:html:report": "npm run combine:reports && npm run create:html:report",
+	"cypress:report:teams": "node scripts/send-cypress-teams-notification.js",
     "zap:report:teams": "node scripts/send-zap-teams-notification.js",
     "lint": "eslint ."
   },

--- a/CypressTests/scripts/send-cypress-teams-notification.js
+++ b/CypressTests/scripts/send-cypress-teams-notification.js
@@ -1,0 +1,251 @@
+const axios = require('axios');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Read and parse the Cypress test report data
+ */
+function readReportData() {
+	let reportStats = { tests: 0, passes: 0, failures: 0 };
+	let failedTests = [];
+
+	const reportPath = path.join(process.cwd(), 'mochareports', 'report.json');
+
+	if (fs.existsSync(reportPath)) {
+		const reportData = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+
+		if (reportData?.stats) {
+			reportStats = {
+				tests: reportData.stats.tests || 0,
+				passes: reportData.stats.passes || 0,
+				failures: reportData.stats.failures || 0,
+			};
+
+			// Only extract failed tests if there are actually failures
+			if (reportStats.failures > 0 && reportData.results) {
+				failedTests = extractFailedTests(reportData.results);
+			}
+		}
+	} else {
+		console.warn('Report file not found at:', reportPath);
+	}
+
+	return { reportStats, failedTests };
+}
+
+/**
+ * Build the adaptive card body with test results and failed test details
+ */
+function buildCardBody(reportStats, failedTests) {
+	const hasFailures = reportStats.failures > 0;
+	const statusText = hasFailures ? '**Cypress Test Run Failed** ❌' : '**Cypress Test Run Passed** ✅';
+
+	const cardBody = [
+		{
+			type: 'TextBlock',
+			wrap: true,
+			text: statusText,
+			size: 'large',
+			horizontalAlignment: 'center',
+		},
+		{
+			type: 'TextBlock',
+			wrap: true,
+			text: '**Branch:** ' + process.env.GITHUB_REF,
+		},
+		{
+			type: 'TextBlock',
+			wrap: true,
+			text: '**Workflow:** ' + process.env.GITHUB_WORKFLOW,
+		},
+		{
+			type: 'TextBlock',
+			wrap: true,
+			text: '**Environment:** ' + process.env.ENVIRONMENT,
+		},
+		{
+			type: 'FactSet',
+			facts: [
+				{ title: 'Total Tests:', value: reportStats.tests.toString() },
+				{ title: 'Passed:', value: reportStats.passes.toString() },
+				{ title: 'Failed:', value: reportStats.failures.toString() },
+			],
+		},
+	];
+
+	// Add failed test details if there are any failures
+	if (hasFailures && failedTests.length > 0) {
+		addFailedTestDetails(cardBody, failedTests);
+	}
+
+	// Add information link
+	cardBody.push({
+		type: 'TextBlock',
+		wrap: true,
+		text: '**See more information:** [' + process.env.INFORMATION_LINK + '](' + process.env.INFORMATION_LINK + ')',
+		spacing: 'medium',
+	});
+
+	return cardBody;
+}
+
+/**
+ * Add failed test details to the card body
+ */
+function addFailedTestDetails(cardBody, failedTests) {
+	cardBody.push({
+		type: 'TextBlock',
+		wrap: true,
+		text: '**Failed Tests:**',
+		weight: 'bolder',
+		spacing: 'medium',
+	});
+
+	// Add each failed test as a separate text block
+	for (const [index, test] of failedTests.entries()) {
+		// Limit to first 10 failed tests to avoid message size limits
+		if (index < 10) {
+			cardBody.push({
+				type: 'TextBlock',
+				wrap: true,
+				text: `**${index + 1}.** ${test.fullTitle}`,
+				weight: 'bolder',
+				spacing: 'small',
+			});
+
+			// Add error message, truncated if too long
+			const errorMessage = truncateText(test.errorMessage, 500);
+			cardBody.push({
+				type: 'TextBlock',
+				wrap: true,
+				text: `*Error:* ${errorMessage}`,
+				spacing: 'none',
+				isSubtle: true,
+			});
+		}
+	}
+
+	// Add note if there are more failures than displayed
+	if (failedTests.length > 10) {
+		cardBody.push({
+			type: 'TextBlock',
+			wrap: true,
+			text: `*... and ${failedTests.length - 10} more failed tests. See full report for details.*`,
+			spacing: 'small',
+			isSubtle: true,
+		});
+	}
+}
+
+/**
+ * Create the Teams message structure
+ */
+function createTeamsMessage(cardBody, hasFailures) {
+	const style = hasFailures ? 'attention' : 'good';
+
+	return {
+		type: 'message',
+		attachments: [
+			{
+				contentType: 'application/vnd.microsoft.card.adaptive',
+				contentUrl: null,
+				content: {
+					$schema: 'https://adaptivecards.io/schemas/adaptive-card.json',
+					type: 'AdaptiveCard',
+					version: '1.2',
+					body: [
+						{
+							type: 'Container',
+							style: style,
+							items: cardBody,
+						},
+					],
+				},
+			},
+		],
+	};
+}
+
+// Recursively extract failed tests from the Cypress report structure
+function extractFailedTests(results) {
+	const failedTests = [];
+
+	function processTestItem(item) {
+		// Check if this is a test with fail: true
+		if (item.fail === true && item.fullTitle && item.err) {
+			failedTests.push({
+				fullTitle: item.fullTitle,
+				errorMessage: cleanErrorMessage(item.err.message || 'No error message available'),
+			});
+		}
+
+		// Process nested tests
+		if (item.tests && Array.isArray(item.tests)) {
+			for (const test of item.tests) {
+				processTestItem(test);
+			}
+		}
+
+		// Process nested suites
+		if (item.suites && Array.isArray(item.suites)) {
+			for (const suite of item.suites) {
+				processTestItem(suite);
+			}
+		}
+	}
+
+	for (const result of results) {
+		processTestItem(result);
+	}
+	return failedTests;
+}
+
+/**
+ * Clean and format error messages for better readability
+ */
+function cleanErrorMessage(errorMessage) {
+	if (!errorMessage) return 'No error message available';
+
+	// Remove stack traces and keep only the main error message
+	const lines = errorMessage.split('\n');
+	const relevantLines = [];
+
+	for (const line of lines) {
+		// Stop at stack trace indicators
+		if (line.includes('    at ') || line.includes('From Your Spec Code:')) {
+			break;
+		}
+
+		// Skip lines that are just URLs or technical details
+		if (!line.includes('https://on.cypress.io/') && !line.includes('webpack://') && line.trim() !== '') {
+			relevantLines.push(line.trim());
+		}
+	}
+
+	return relevantLines.join(' ').trim() || errorMessage.split('\n')[0];
+}
+
+/**
+ * Truncate text to specified length with ellipsis
+ */
+function truncateText(text, maxLength) {
+	if (!text || text.length <= maxLength) return text;
+	return text.substring(0, maxLength) + '...';
+}
+
+// used in GitHub Actions to send Cypress test results to Microsoft Teams channel via webhook
+async function sendTeamsNotification() {
+	try {
+		const { reportStats, failedTests } = readReportData();
+		const cardBody = buildCardBody(reportStats, failedTests);
+		const message = createTeamsMessage(cardBody, reportStats.failures > 0);
+
+		await axios.post(process.env.TEAMS_WEBHOOK_URL, message);
+		console.log('Message sent to Teams successfully');
+	} catch (error) {
+		console.error('Error sending notification to Teams:', error);
+		process.exit(1);
+	}
+}
+
+sendTeamsNotification(); //NOSONAR

--- a/CypressTests/scripts/send-zap-teams-notification.js
+++ b/CypressTests/scripts/send-zap-teams-notification.js
@@ -58,9 +58,23 @@ function createZapClient() {
 }
 
 async function fetchScanResults() {
-  const zaproxy = createZapClient();
-  const summaryResponse = await zaproxy.core.alertsSummary({});
-  return summaryResponse.alertsSummary ?? {};
+	const zaproxy = createZapClient();
+	const {alerts} = await zaproxy.alert.alerts({});
+
+	const distinctRefsByRisk = {
+		High: new Set(),
+		Medium: new Set(),
+		Low: new Set(),
+		Informational: new Set(),
+	};
+
+	for (const alert of alerts) {
+		distinctRefsByRisk[alert.risk]?.add(alert.alertRef || alert.pluginId);
+	}
+
+	return Object.fromEntries(
+		Object.entries(distinctRefsByRisk).map(([risk, refs]) => [risk, refs.size]),
+	);
 }
 
 function getAlertCount(summary, level) {


### PR DESCRIPTION
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/288866
- minor fix for this change, to give alert count, not instant count
- run cypress only on test, run cypress with scan on dev
- output cypress results to academisation-cypress-automation-reports teams channel