### PR TITLE
Add packages: read permission to validate-packages job

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -43,6 +43,7 @@ jobs:
     name: Package Validation
     permissions:
       contents: read
+      packages: read
     needs: [ set-env ]
     steps:
       - name: Validate Packages


### PR DESCRIPTION
Add packages: read permission to validate-packages job

Updated the validate-packages job in build-and-push-image.yml to include the packages: read permission. This change enables the job to access and read GitHub Packages during its execution.